### PR TITLE
update fishrappr db migrations

### DIFF
--- a/db/migrate/20160413202246_add_issues.rb
+++ b/db/migrate/20160413202246_add_issues.rb
@@ -2,12 +2,11 @@
 class AddIssues < ActiveRecord::Migration
   def self.up      
     create_table :issues do |t|
-      # t.integer  :issue_id # not needed because active record creates an id column
       t.string  :hathitrust
       t.string  :volume
-      t.string :issue_no
-      t.string :edition
-      t.string  :dateIssued
+      t.string  :issue_no
+      t.string  :edition
+      t.string  :date_issued
       t.string  :newspaper
       t.integer :pages_count #active record automatically add the number of pages in this issue here
 

--- a/db/migrate/20160413202246_add_issues.rb
+++ b/db/migrate/20160413202246_add_issues.rb
@@ -2,18 +2,19 @@
 class AddIssues < ActiveRecord::Migration
   def self.up      
     create_table :issues do |t|
-      t.integer :issue_id
+      # t.integer  :issue_id # not needed because active record creates an id column
       t.string  :hathitrust
-      t.integer :volume
-      t.integer :issue_no
-      t.integer :edition
-      t.string :dateIssued
-      t.string :newspaper
+      t.string  :volume
+      t.string :issue_no
+      t.string :edition
+      t.string  :dateIssued
+      t.string  :newspaper
+      t.integer :pages_count #active record automatically add the number of pages in this issue here
 
       t.timestamps null: false
     end
 
-    add_index :issues, :issue_id
+    add_index :issues, :id
   end
 
   def self.down

--- a/db/migrate/20160413202258_add_pages.rb
+++ b/db/migrate/20160413202258_add_pages.rb
@@ -1,7 +1,6 @@
 class AddPages < ActiveRecord::Migration
   def self.up
     create_table :pages do |t|
-      # t.integer  :page_id  # not needed because active record creates an id column
       t.integer  :issue_id
       t.string   :page_no
       t.string   :page_order

--- a/db/migrate/20160413202258_add_pages.rb
+++ b/db/migrate/20160413202258_add_pages.rb
@@ -1,17 +1,18 @@
 class AddPages < ActiveRecord::Migration
   def self.up
     create_table :pages do |t|
-      t.integer  :page_id
-      t.integer  :page_no
-      t.integer  :page_order
-      t.integer  :issue_no
+      # t.integer  :page_id  # not needed because active record creates an id column
+      t.integer  :issue_id
+      t.string   :page_no
+      t.string   :page_order
+      t.string   :issue_no
       t.string   :text_link
       t.string   :img_link
 
       t.timestamps null: false
     end
 
-    add_index :pages, :page_id
+    add_index :pages, :id
   end
 
   def self.down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,31 +26,31 @@ ActiveRecord::Schema.define(version: 20160413202258) do
   add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id"
 
   create_table "issues", force: :cascade do |t|
-    t.integer  "issue_id"
     t.string   "hathitrust"
-    t.integer  "volume"
-    t.integer  "issue_no"
-    t.integer  "edition"
+    t.string   "volume"
+    t.string  "issue_no"
+    t.string  "edition"
     t.string   "dateIssued"
     t.string   "newspaper"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "pages_count"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
-  add_index "issues", ["issue_id"], name: "index_issues_on_issue_id"
+  add_index "issues", ["id"], name: "index_issues_on_id"
 
   create_table "pages", force: :cascade do |t|
-    t.integer  "page_id"
-    t.integer  "page_no"
-    t.integer  "page_order"
-    t.integer  "issue_no"
+    t.integer  "issue_id"
+    t.string   "page_no"
+    t.string   "page_order"
+    t.string   "issue_no"
     t.string   "text_link"
     t.string   "img_link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "pages", ["page_id"], name: "index_pages_on_page_id"
+  add_index "pages", ["id"], name: "index_pages_on_id"
 
   create_table "searches", force: :cascade do |t|
     t.text     "query_params"


### PR DESCRIPTION
Update fishrappr db migrations
On issues table:
-- removed :issue_id because AR automatically add an id column
-- changed :volume, :issue_no, and :edition from integers to strings

On pages table:
-- removed page_id because AR automatically add an id column
-- changed :page_no, :page_order, and :issue_no from integers to strings