### PR TITLE
update migrations

### DIFF
--- a/db/migrate/20160413202246_add_issues.rb
+++ b/db/migrate/20160413202246_add_issues.rb
@@ -2,18 +2,18 @@
 class AddIssues < ActiveRecord::Migration
   def self.up      
     create_table :issues do |t|
-      t.integer :issue_id
       t.string  :hathitrust
-      t.integer :volume
-      t.integer :issue_no
-      t.integer :edition
-      t.string :dateIssued
-      t.string :newspaper
+      t.string  :volume
+      t.string  :issue_no
+      t.string  :edition
+      t.string  :date_issued
+      t.string  :newspaper
+      t.integer :pages_count
 
       t.timestamps null: false
     end
 
-    add_index :issues, :issue_id
+    add_index :issues, :id
   end
 
   def self.down

--- a/db/migrate/20160413202258_add_pages.rb
+++ b/db/migrate/20160413202258_add_pages.rb
@@ -1,17 +1,17 @@
 class AddPages < ActiveRecord::Migration
   def self.up
     create_table :pages do |t|
-      t.integer  :page_id
-      t.integer  :page_no
-      t.integer  :page_order
-      t.integer  :issue_no
+      t.integer  :issue_id
+      t.string   :page_no
+      t.string   :page_order
+      t.string   :issue_no
       t.string   :text_link
       t.string   :img_link
 
       t.timestamps null: false
     end
 
-    add_index :pages, :page_id
+    add_index :pages, :id
   end
 
   def self.down


### PR DESCRIPTION
Clean up migrations as discussed:

1. Modified issues table to remove issue_id, add pages_count, and switch volume, issue_no, and edition to strings.
2. Modified pages table to remove page_id, add issue_id, and switch page_no, page_order, and issue_no to strings.

TO USE REMOVE CURRENT db file development.sqlite3 and db/schema.rb files and rerun migrations