### PR TITLE
Start of helpers to pull image derivatives from HathiTrust imgsrv.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.1.0'
+### gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'therubyracer', platforms: :ruby
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
@@ -34,9 +34,13 @@ gem 'blacklight'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'puma'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'pry-byebug'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (8.2.4)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -113,6 +114,7 @@ GEM
       unf
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
+    method_source (0.8.2)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0221)
@@ -122,6 +124,16 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    puma (3.4.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -227,11 +239,13 @@ DEPENDENCIES
   blacklight
   blacklight-marc (~> 6.0)
   byebug
-  coffee-rails (~> 4.1.0)
   devise
   devise-guests (~> 0.3)
   jbuilder (~> 2.0)
   jquery-rails
+  pry-byebug
+  pry-rails
+  puma
   rails (= 4.2.6)
   rsolr (~> 1.0)
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the static controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,22 @@
+class StaticController < ApplicationController
+
+  def page
+
+    @page = SolrDocument.new(
+      {
+        "id":"1",
+        "issue_no_t":["1"],
+        "issue_date_dt":"1899-09-23T00:00:00Z",
+        "issueid_t":["2"],
+        "page_no_t":["1"],
+        "sequence_i":1,
+        "hathitrust_t":["mdp.39015071730837"],
+        "text_link_t":["TXT00000005"],
+        "img_link_t":["IMG00000005"],
+        "timestamp":"2016-04-27T16:03:28.035Z"
+      }
+    )
+
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,31 @@
 module ApplicationHelper
+
+  def hathitrust_image_src(document, **kw)
+    barcode = document.fetch('hathitrust_t').first
+    barcode = 'mdp.39015071754159'
+
+    img_link = document.fetch('img_link_t').first
+
+    region = kw.fetch(:region, 'full')
+    size = kw.fetch(:size, 'full')
+    rotation = kw.fetch(:rotation, '0')
+    quality = kw.fetch(:quality, 'default')
+    format = kw.fetch(:format, 'jpg')
+
+    "#{Rails.configuration.iiif_service}#{barcode}/#{img_link}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
+  end
+
+  def hathitrust_thumbnail_src(document, **kw)
+    size = kw.fetch(:size, ',250')
+    hathitrust_image_src(document, size: size)
+  end
+
+  def hathitrust_image(document, **kw)
+    %Q{<img src="#{hathitrust_image_src(document, **kw)}" />}.html_safe
+  end
+
+  def hathitrust_thumbnail(document, **kw)
+    %Q{<img src="#{hathitrust_thumbnail_src(document, **kw)}" />}.html_safe
+  end
+
 end

--- a/app/helpers/static_helper.rb
+++ b/app/helpers/static_helper.rb
@@ -1,0 +1,2 @@
+module StaticHelper
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,7 +9,10 @@ class Page < ActiveRecord::Base
     i = Issue.find_by_id(issue_id)
     conn = Blacklight.default_index.connection
     d = i.date_issued.to_date
-    doc = { id: self.id, issue_no_t:i.issue_no, issue_date_dt: d, page_no_t:page_no, issueid_t: issue_id, sequence_i: sequence, text_link_t: text_link, img_link_t: img_link }
+    doc = { id: self.id, issue_no_t:i.issue_no, issue_date_dt: d, issueid_t: issue_id, 
+            page_no_t:page_no, sequence_i: sequence,
+            hathitrust_t: i.hathitrust,
+            text_link_t: text_link, img_link_t: img_link }
     conn.add doc
     conn.commit
   end

--- a/app/views/static/page.html.erb
+++ b/app/views/static/page.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+    <div class="col-md-12">
+        <pre>AHOY</pre>
+        <pre><%= hathitrust_image_src(@page) %></pre>
+
+        <p>
+            <%= hathitrust_image(@page, size: '500,') %>
+        </p>
+
+        <p>
+            <%= hathitrust_thumbnail(@page) %>
+        </p>
+
+    </div>
+</div>

--- a/app/views/static/test.html.erb
+++ b/app/views/static/test.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+    <div class="col-md-12">
+        <pre>AHOY</pre>
+
+        <form>
+            <p>
+                # 1 - 
+                Year:
+                    <input name="data[][yyyy]" />
+                Month:
+                    <input name="data[][nn]" />
+            </p>
+            <p>
+                #2 - 
+                Year :
+                    <input name="data[][yyyy]" />
+                Month:
+                    <input name="data[][nn]" />
+            </p>
+            <p>
+                # 3 - 
+                Year:
+                    <input name="data[][yyyy]" />
+                Month:
+                    <input name="data[][nn]" />
+            </p>
+            <p>
+                <input type="submit" />
+            </p>
+        </form>
+    </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Fishrappr
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.iiif_service = 'https://beta-3.babel.hathitrust.org/cgi/imgsrv/iiif/'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     end
   end
 
-
+  get 'static/:action' => 'static'
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/lib/tasks/fishrappr.rake
+++ b/lib/tasks/fishrappr.rake
@@ -1,0 +1,10 @@
+namespace :fishrappr do
+  desc "Reindex pages"
+  task reindex_pages: :environment do    
+    Page.all.each do |page|
+      page.remove_from_index
+      page.index_record
+      STDERR.puts "#{page.id}"
+    end
+  end
+end

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StaticControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Added hathitrust_image and hathitrust_thumbnail helpers to setup image references from the solr document.

Added `hathitrust` identifier to page solr document.

Added rake task to reindex pages (`rake fishrappr:reindex_pages`).

- added pry
- added puma
- remove coffeescript