### PR TITLE
tasks + helpers for using fake data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ bower.json
 
 # Ignore byebug history
 .byebug_history
+
+# Ignore MacOSX
+.DS_Store
 	

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  gem 'ffaker'
+  gem 'holder_rails'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,12 @@ GEM
     dot-properties (0.1.3)
     erubis (2.7.0)
     execjs (2.6.0)
+    ffaker (2.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.3)
+    holder_rails (2.9.3)
+      railties (>= 3.1.0)
     httpclient (2.7.1)
     i18n (0.7.0)
     jbuilder (2.4.1)
@@ -241,6 +244,8 @@ DEPENDENCIES
   byebug
   devise
   devise-guests (~> 0.3)
+  ffaker
+  holder_rails
   jbuilder (~> 2.0)
   jquery-rails
   pry-byebug

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,5 +15,6 @@
 //= require turbolinks//
 // Required by Blacklight
 //= require blacklight/blacklight
+//= require holder
 
 //= require_tree .

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,6 @@ module ApplicationHelper
 
   def hathitrust_image_src(document, **kw)
     barcode = document.fetch('hathitrust_t').first
-    barcode = 'mdp.39015071754159'
 
     img_link = document.fetch('img_link_t').first
 
@@ -21,14 +20,29 @@ module ApplicationHelper
   end
 
   def hathitrust_image(document, **kw)
+    barcode = document.fetch('hathitrust_t').first
+    return fake_image if barcode != 'mdp.39015071754159'
     %Q{<img src="#{hathitrust_image_src(document, **kw)}" />}.html_safe
   end
 
   def hathitrust_thumbnail(document, **kw)
+    barcode = document.fetch('hathitrust_t').first
+    return fake_image(kw.fetch(:size, ',250')) if barcode != 'mdp.39015071754159'
     %Q{<img src="#{hathitrust_thumbnail_src(document, **kw)}" />}.html_safe
   end
 
   def render_date_format(args)
     args.to_date.strftime("%B %d, %Y")
   end  
+
+  require 'ffaker'
+  def fake_image(size=nil)
+    if size == ',150'
+      return holder_tag "110x150", FFaker::CheesyLingo.title
+    elsif size == ",250"
+      return holder_tag "187x250", FFaker::CheesyLingo.title
+    else
+      return holder_tag "375x500", FFaker::CheesyLingo.sentence
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,9 +38,9 @@ module ApplicationHelper
   require 'ffaker'
   def fake_image(size=nil)
     if size == ',150'
-      return holder_tag "110x150", FFaker::CheesyLingo.title
+      return holder_tag "110x150", FFaker::CheesyLingo.title, nil, {}, { 'random' => 'yes' }
     elsif size == ",250"
-      return holder_tag "187x250", FFaker::CheesyLingo.title
+      return holder_tag "187x250", FFaker::CheesyLingo.title, nil, {}, { 'random' => 'yes' }
     else
       return holder_tag "375x500", FFaker::CheesyLingo.sentence
     end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,25 +6,32 @@ class Page < ActiveRecord::Base
   #attr_accessible :issue_id, page_no, sequence, text_link, img_link
 
   def index_record
+    return unless Rails.configuration.index_enabled
     i = Issue.find_by_id(issue_id)
     conn = Blacklight.default_index.connection
     d = i.date_issued.to_date
     dt = d.strftime('%B %d, %Y')
-    full_text = ''
-    full_text = File.read(Rails.root.join('tmp/txt_files/'+ text_link+'.txt'))
+    full_text = get_full_text(i, text_link)
     doc = { id: self.id, issue_date_display:dt, issue_no_t:i.issue_no, issue_date_dt: d, issue_id_t: issue_id, 
             page_no_t:page_no, sequence_i: sequence,
             hathitrust_t: i.hathitrust,
             text_link_t: text_link, img_link_t: img_link, full_text_txt:full_text }
 
     conn.add doc
-    conn.commit
+    conn.commit unless Rails.configuration.batch_commit
   end
 
   def remove_from_index
     conn = Blacklight.default_index.connection 
     conn.delete_by_id(self.id)
     conn.commit
+  end
+
+  def get_full_text(issue, text_link)
+    File.read(Rails.root.join(
+      Rails.configuration.text_root, 
+      issue.hathitrust, 
+      text_link+'.txt'))
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module Fishrappr
     config.active_record.raise_in_transactional_callbacks = true
 
     config.iiif_service = 'https://beta-3.babel.hathitrust.org/cgi/imgsrv/iiif/'
+    config.text_root = "tmp/fake_data"
+    config.index_enabled = true
   end
 end

--- a/lib/tasks/fishrappr.rake
+++ b/lib/tasks/fishrappr.rake
@@ -7,4 +7,21 @@ namespace :fishrappr do
       STDERR.puts "#{page.id}"
     end
   end
+
+  desc "Index pages (does not remove)"
+  task index_pages: :environment do
+    Rails.configuration.batch_commit = true
+    t0 = Time.now
+    total_pages = Page.count
+    Page.all.each_with_index do |page, i|
+      page.index_record
+      if i % 5000 == 0
+        Blacklight.default_index.connection.commit
+        t1 = Time.now
+        STDERR.puts "-- committed: #{i} / #{total_pages} : #{t1 - t0}"
+        t0 = t1
+      end
+    end
+  end
+
 end

--- a/lib/tasks/populate_fake_data.rake
+++ b/lib/tasks/populate_fake_data.rake
@@ -1,0 +1,99 @@
+unless Rails.env.production?
+  require 'yaml'
+
+  require 'ffaker'
+
+  namespace :fishrappr do
+
+    desc "Populate database with much fake data."
+    task :populate_fake_data, [:dates_filename] => :environment do |t, args|
+      ENV["RAILS_ENV"] ||= "development"
+
+      fake_setup(args[:dates_filename])
+
+      puts "Done."
+    end
+
+    task :verify_dates, [:dates_filename] => :environment do |t, args|
+      File.open(args[:dates_filename]).each do |line|
+        line.strip!
+        begin
+          timestamp = line.to_date
+        rescue => e
+          STDERR.puts "#{line} : #{e}"
+        end
+      end
+    end
+
+  end
+
+  def fake_setup(dates_filename)
+    Page.destroy_all
+
+    volume_idx = {}
+
+    Rails.configuration.batch_commit = true
+    Rails.configuration.index_enabled = false
+
+    File.open(dates_filename).each do |line|
+      line.strip!
+      next unless line
+
+      begin
+        timestamp = line.to_date
+      rescue => e
+        STDERR.puts "#{line} : #{e}"
+        next
+      end
+
+      STDERR.puts line
+
+      t0 = Time.now
+
+      volume = line.split('-')[1]
+      issue_no = volume_idx.fetch(volume, 0) + 1
+      volume_idx[volume] = issue_no
+
+      pages_count = rand(15)
+      hathitrust = "mdp.#{FFaker::IdentificationESCO.drivers_license}"
+
+      # make an issue
+      issue = Issue.create(
+        hathitrust: hathitrust,
+        volume: volume,
+        date_issued: line,
+        issue_no: issue_no.to_s,
+        pages_count: pages_count,
+        newspaper: "Michigan Daily",
+      )
+
+      (1 .. pages_count ).each do |seq|
+        # make a new text file
+        text_file_id = "TXT#{'%08d' % seq}"
+        image_file_id = "IMAGE#{'%08d' % seq}"
+
+        if not Dir.exists?("./tmp/fake_data/#{hathitrust}")
+          Dir.mkdir("./tmp/fake_data/#{hathitrust}")
+        end
+
+        File.open("./tmp/fake_data/#{hathitrust}/#{text_file_id}.txt", 'w') do |io|
+          io.puts FFaker::CheesyLingo.paragraph
+          io.puts FFaker::CheesyLingo.paragraph
+        end
+
+        page = Page.create(
+          issue_id: issue.id,
+          page_no: seq.to_s,
+          sequence: seq,
+          text_link: text_file_id,
+          img_link: image_file_id,
+        )
+
+      end
+
+      Blacklight.default_index.connection.commit
+      STDERR.puts "-- #{line} : #{Time.now - t0}"
+
+    end
+  end
+end


### PR DESCRIPTION
Added tasks and support for fake data.

To make this efficient, added configuration options to `application.rb` which we will need to revisit with proper configuration options. Mostly this allows for **disabling indexing** and **managing solr commits** which can speed up data loads immensely.