### PR TITLE
initial attempts at hacking the paths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,4 +299,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.1

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2,6 +2,7 @@
 class CatalogController < ApplicationController
 
   include Blacklight::Catalog
+  include Fishrappr::Catalog
 
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
@@ -12,6 +13,7 @@ class CatalogController < ApplicationController
     #
     ## Model that maps search index responses to the blacklight response model
     # config.response_model = Blacklight::Solr::Response
+    config.document_presenter_class = Fishrappr::DocumentPresenter
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
@@ -113,6 +115,12 @@ class CatalogController < ApplicationController
     config.add_show_field 'page_no_t', label: 'Page No'
     config.add_show_field 'sequence_i', label: 'Page Order'
     config.add_show_field 'full_text_txt', label: 'Page Text'
+
+    config.add_show_field 'next_page_link', label: 'Next Page Link'
+    config.add_show_field 'next_page_label', label: 'Next Page Label'
+    config.add_show_field 'prev_page_link', label: 'Previous Page Link'
+    config.add_show_field 'prev_page_label', label: 'Previous Page Label'
+
     #config.add_show_field 'img_link_t', label: 'Image', helper_method: :hathitrust_image_src(document)
 
     # "fielded" search configuration. Used by pulldown among other places.
@@ -173,5 +181,8 @@ class CatalogController < ApplicationController
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true
     config.autocomplete_path = 'suggest'
+
+    config.show.route = { controller: 'catalog', action: 'browse_issue_page' }
+    # binding.pry
   end
 end

--- a/app/controllers/concerns/fishrappr/catalog.rb
+++ b/app/controllers/concerns/fishrappr/catalog.rb
@@ -1,0 +1,63 @@
+require 'fishrappr/search_state'
+module Fishrappr::Catalog
+  extend ActiveSupport::Concern
+
+  include Blacklight::Base
+
+  def browse_issue_page
+    @response, @document = fetch_issue params[:issue_date], params[:sequence]
+    setup_next_and_previous_documents; setup_next_and_previous_issue_pages
+    render "show"
+  end
+
+  # get a single document from the index
+  # to add responses for formats other than html or json see _Blacklight::Document::Export_
+  def show
+    @response, @document = fetch params[:id]
+
+    respond_to do |format|
+      format.html { setup_next_and_previous_documents; setup_next_and_previous_issue_pages }
+      format.json { render json: { response: { document: @document } } }
+
+      additional_export_formats(@document, format)
+    end
+  end
+
+  def fetch_issue(issue_date, sequence, extra_controller_params={})
+    fq = [ %Q{issue_date_dt:"#{issue_date.to_date.strftime("%Y-%m-%dT00:00:00Z")}"}, "sequence_i:#{sequence}" ]
+    # solr_response = repository.search fq: [ "issue_date_dt" => issue_date.to_date.strftime("%Y-%m-%dT00:00:00Z"), "sequence_i" => sequence ], fl: '*'
+    solr_response = repository.search fq: fq, fl: '*'
+    [solr_response, solr_response.documents.first]
+  end
+
+  def setup_next_and_previous_issue_pages
+    sequence = @document.fetch('sequence_i')
+    @previous_page = @next_page = nil
+    begin
+      response, @previous_page = fetch @document.fetch('prev_page_link')
+    rescue Exception => e
+      STDERR.puts "PREVIOUS : #{e}"
+    end
+    begin
+      response, @next_page = fetch @document.fetch('next_page_link')
+    rescue Exception => e
+      STDERR.puts "NEXT : #{e}"
+    end
+    # response, documents = get_previous_and_next_documents_for_issue_page sequence, ActiveSupport::HashWithIndifferentAccess.new(current_search_session.query_params)
+    # @search_page_response = response
+    # @previous_page = documents.first
+    # @next_page = document.last
+  rescue Blacklight::Exceptions::InvalidRequest => e
+    logger.warn "Unable to setup next and previous documents: #{e}"
+  end
+
+  def repository
+    @repository ||= repository_class.new(blacklight_config)
+  end
+
+  def search_state
+    # binding.pry
+    @search_state ||= Fishrappr::SearchState.new(params, blacklight_config)
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,23 @@
 module ApplicationHelper
 
+  ##
+  # Link to the previous document in the current search context
+  def link_to_previous_issue_page(previous_document)
+    link_opts = {}
+    link_to_unless previous_document.nil?, raw(t('views.issue.previous')), url_for_document(previous_document), link_opts do
+      content_tag :span, raw(t('views.issue.previous')), :class => 'previous'
+    end
+  end
+
+  ##
+  # Link to the next document in the current search context
+  def link_to_next_issue_page(next_document)
+    link_opts = {}
+    link_to_unless next_document.nil?, raw(t('views.issue.next')), url_for_document(next_document), link_opts do
+      content_tag :span, raw(t('views.issue.next')), :class => 'next'
+    end
+  end
+
   def hathitrust_image_src(document, **kw)
     barcode = document.fetch('hathitrust_t').first
 

--- a/app/helpers/zzzzzz_helper.rb
+++ b/app/helpers/zzzzzz_helper.rb
@@ -1,0 +1,9 @@
+module ZzzzzzHelper
+
+  # def url_for_document(doc, options = {})
+  #   retval = search_state.url_for_document(doc, options)
+  #   STDERR.puts "RETVAL = #{retval}"
+  #   retval
+  # end
+
+end

--- a/app/indexers/issue_indexer.rb
+++ b/app/indexers/issue_indexer.rb
@@ -36,6 +36,7 @@ class IssueIndexer
     pp @issue
     dt = d.strftime('%B %d, %Y')
 
+    solr_doc[:id] = @issue.date_issued
     solr_doc[:issue_date_display] = dt
     solr_doc[:issue_no_t] = @issue.issue_no
     solr_doc[:issue_date_dt] = d
@@ -44,7 +45,13 @@ class IssueIndexer
     solr_doc[:pages] = []
 
     Page.where(issue_id: issue.id).order(:sequence).each do |page|
-      solr_doc[:pages] << [ page.id, page.sequence, page.page_no ]
+      # solr_doc[:pages] << [ page.id, page.sequence, page.page_no ]
+      solr_doc[:pages] << [
+        page.id,
+        "#{@issue.date_issued}-#{page.sequence}",
+        page.sequence,
+        page.page_no
+      ]
     end
     solr_doc
   end

--- a/app/indexers/page_indexer.rb
+++ b/app/indexers/page_indexer.rb
@@ -9,18 +9,19 @@ class PageIndexer
   def generate_solr_doc(issue_doc)
 
     full_text = get_full_text(issue_doc[:hathitrust_t], @page.text_link)
+    page_id = "#{issue_doc[:id]}-#{@page.sequence}"
     solr_doc = { 
-      id: @page.id,
+      id: page_id, # @page.id,
       page_no_t:@page.page_no, sequence_i: @page.sequence,
       text_link_t: @page.text_link, 
       img_link_t: @page.img_link, 
       full_text_txt:full_text,
-      next_page_id_i: nil,
-      prev_page_id_i: nil,
-      next_page_sequence_i: nil,
-      prev_page_sequence_i: nil,
-      next_page_display: nil,
-      prev_page_display: nil
+      prev_page_link: nil,
+      next_page_link: nil,
+      next_page_sequence_label: nil,
+      prev_page_sequence_label: nil,
+      next_page_label: nil,
+      prev_page_label: nil
     }
 
     current_index = issue_doc[:pages].index { |v| v[0] == @page.id }
@@ -29,14 +30,14 @@ class PageIndexer
     end
 
     unless current_index - 1 < 0
-      solr_doc[:prev_page_id_i] = issue_doc[:pages][current_index - 1][0]
-      solr_doc[:prev_page_sequence_i] = issue_doc[:pages][current_index - 1][1]
-      solr_doc[:prev_page_display] = issue_doc[:pages][current_index - 1][2]
+      solr_doc[:prev_page_link] = issue_doc[:pages][current_index - 1][1]
+      solr_doc[:prev_page_sequence_label] = issue_doc[:pages][current_index - 1][2]
+      solr_doc[:prev_page_label] = issue_doc[:pages][current_index - 1][3]
     end
     if current_index + 1 < ( issue_doc[:pages].size - 1 )
-      solr_doc[:next_page_id_i] = issue_doc[:pages][current_index + 1][0]
-      solr_doc[:next_page_sequence_i] = issue_doc[:pages][current_index + 1][1]
-      solr_doc[:next_page_display] = issue_doc[:pages][current_index + 1][2]
+      solr_doc[:next_page_link] = issue_doc[:pages][current_index + 1][1]
+      solr_doc[:next_page_sequence_label] = issue_doc[:pages][current_index + 1][2]
+      solr_doc[:next_page_label] = issue_doc[:pages][current_index + 1][3]
     end
 
     solr_doc

--- a/app/presenters/fishrappr/document_presenter.rb
+++ b/app/presenters/fishrappr/document_presenter.rb
@@ -1,0 +1,35 @@
+require 'pp'
+module Fishrappr
+  class DocumentPresenter < Blacklight::DocumentPresenter
+
+    def has_next_page?
+      @document['next_page_link'] != nil
+    end
+
+    def has_prev_page?
+      @document['prev_page_link'] != nil
+    end
+
+    def next_page_link
+      @document['next_page_sequence_label']
+    end
+
+    def next_page_label
+      @document['next_page_label']
+    end
+
+    def prev_page_link
+      @document['prev_page_sequence_label']
+    end
+
+    def prev_page_label
+      @document['prev_page_label']
+    end
+
+    def issue_date
+      @document['issue_date_dt'].split('T')[0]
+    end
+
+
+  end
+end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,11 @@
 <div id="content" class="<%= show_content_classes %>">
+  <div class="pagination-search-widgets">
+    <div class="pull-right search-widgets">
+      <%= link_to_previous_issue_page @previous_page %>
+       | 
+      <%= link_to_next_issue_page @next_page %>
+    </div>
+  </div>
   <%= render_document_main_content_partial %>
   <%= hathitrust_image(@document, size: '500,') %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Fishrappr
     config.text_root = "tmp/fake_data"
     config.index_enabled = true
     config.batch_commit = true
+
+    config.autoload_paths += Dir["#{config.root}/lib/**/*"]
+
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,7 @@
 
 en:
   hello: "Hello world"
+  views:
+    issue:
+        next: "Next Page"
+        previous: "Previous Page"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
+
+  get 'browse/:issue_date/:sequence' => 'catalog#browse_issue_page', as: :browse_issue_page
   
   mount Blacklight::Engine => '/'
   root to: "catalog#index"
-    concern :searchable, Blacklight::Routes::Searchable.new
+  concern :searchable, Blacklight::Routes::Searchable.new
+
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
@@ -10,6 +13,10 @@ Rails.application.routes.draw do
 
   devise_for :users
   concern :exportable, Blacklight::Routes::Exportable.new
+
+  # resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
+  #   concerns :exportable
+  # end
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable

--- a/lib/fishrappr/search_state.rb
+++ b/lib/fishrappr/search_state.rb
@@ -1,0 +1,21 @@
+module Fishrappr
+  class SearchState < Blacklight::SearchState
+
+    def url_for_document(doc, options = {})
+      if doc and respond_to?(:blacklight_config) and
+          blacklight_config.show.route and
+          (!doc.respond_to?(:to_model) or doc.to_model.is_a? SolrDocument)
+        # route = blacklight_config.show.route.merge(action: :show, id: doc).merge(options)
+        route = blacklight_config.show.route.merge(issue_date: doc.fetch('issue_date_dt').split('T')[0], sequence: doc.fetch('sequence_i')).merge(options)
+        route.delete(:id)
+        route[:controller] = params[:controller] if route[:controller] == :current
+        route
+      else
+        doc
+      end
+    end
+
+
+
+  end
+end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -530,6 +530,11 @@
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
+   <!-- from curation concerns -->
+   <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
+   <dynamicField name="*_link" type="string" stored="true" indexed="true" multiValued="false"/>
+   <dynamicField name="*_label" type="string" stored="true" indexed="false" multiValued="false"/>
+
    <!-- uncomment the following to ignore any fields that don't already match an existing 
         field name or dynamic field, rather than reporting them as an error. 
         alternately, change the type="ignored" to some other type e.g. "text" if you want 


### PR DESCRIPTION
- solrdoc paths default to /browse/:issue_date/:sequence
- adds support for calculating next_page and previous_page within the issue
- adds previous page/previous page when viewing pages

YOU WILL NEED TO REINDEX PAGES AGAINST A FRESH SOLR INDEX: `bundle exec rake fishrappr:reindex_pages`