### PR TITLE
simple grid view

### DIFF
--- a/app/assets/stylesheets/grid.scss
+++ b/app/assets/stylesheets/grid.scss
@@ -1,0 +1,41 @@
+.gallery {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.gallery > div {
+    flex: 0 0 auto;
+    margin: 10px;
+
+    padding: 10px;
+    width: 225px;
+    text-align: center;
+    border: 1px solid #eee;
+
+    img {
+        max-width: 100%;
+        height: auto !important;
+    }
+
+    .caption {
+        text-align: left;
+    }
+
+    .document-metadata {
+        dt {
+            display: block;
+            float: none;
+            text-align: left;
+        }
+
+        dd {
+            margin-left: 5px;
+        }
+
+        .blacklight-full_text_txt {
+            display: none !important;
+        }
+    }
+    
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -27,7 +27,7 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
-      rows: 10,
+      rows: 24,
       :qt => 'search',
       :qf => 'full_text_txt',
       :hl => true,
@@ -44,6 +44,7 @@ class CatalogController < ApplicationController
 
     # items to show per page, each number in the array represent another option to choose from.
     #config.per_page = [10,20,50,100]
+    config.per_page = [ 24, 48, 144 ]
 
     ## Default parameters to send on single-document requests to Solr. These settings are the Blackligt defaults (see SearchHelper#solr_doc_params) or
     ## parameters included in the Blacklight-jetty document requestHandler.
@@ -57,6 +58,8 @@ class CatalogController < ApplicationController
     }
 
     config.document_index_view_types = ["default", "gallery", "list", "frequency", "covers"]
+    config.view.grid.partials = [:index]
+    config.view.grid.icon_class = "glyphicon-th-large"
 
     # solr field configuration for search results/index views
      config.index.title_field = 'issue_date_display'

--- a/app/views/catalog/_document_grid.html.erb
+++ b/app/views/catalog/_document_grid.html.erb
@@ -1,0 +1,3 @@
+<div id="documents" class="row grid">
+    <%= render collection: documents, as: :document, partial: 'index_grid' %>
+</div>

--- a/app/views/catalog/_index_grid.html.erb
+++ b/app/views/catalog/_index_grid.html.erb
@@ -1,0 +1,6 @@
+<div>
+    <%= link_to hathitrust_thumbnail(document, size: '200,'), document %>
+    <div class="caption">
+        <%= render_document_partials document, blacklight_config.view_config(:grid).partials, document_counter: document_counter %>
+    </div>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,4 +1,9 @@
 en:
   blacklight:
     application_name: 'Fishrappr'
+    search:
+      view:
+        list: "List"
+        grid: "Grid"
+
 


### PR DESCRIPTION
Simple grid view for search results, based on SearchWorks. Stylesheet currently hides the fulltext field pending further investigation.

The number of results has been changed to [ 24, 48, 144 ] to prevent orphan rows in the grid.