### PR TITLE
Support for publications, adding barcodes to path, etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,8 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0'
-  gem 'rubocop', '~> 0.37.2'
-  gem 'rubocop-rspec'
+  gem 'rubocop', '~> 0.37.2', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :development do

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,12 +62,12 @@ class CatalogController < ApplicationController
     config.view.grid.icon_class = "glyphicon-th-large"
 
     # solr field configuration for search results/index views
-     config.index.title_field = 'issue_date_display'
+     config.index.title_field = 'date_issued_display'
 #    config.index.page_no_field = 'page_no_t'
 
     # solr field configuration for document/show views
-     config.show.title_field = 'issue_date_display'
-#    config.show.issue_date_field = 'issue_date_t'
+     config.show.title_field = 'date_issued_display'
+#    config.show.date_issued_field = 'date_issued_t'
 #    config.index.page_no_field = 'page_no_t'
 
 
@@ -96,7 +96,7 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'issue_date_dt', label: 'Issue Date', helper_method: :render_date_format
+    config.add_facet_field 'date_issued_dt', label: 'Issue Date', helper_method: :render_date_format
     config.add_facet_field 'issue_no_t', label: 'Issue No'
 
     #config.add_facet_field 'example_pivot_field', label: 'Pivot Field', :pivot => ['format', 'language_facet']
@@ -115,18 +115,18 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    #config.add_index_field 'issue_date_dt', label: 'Issue Date'
+    #config.add_index_field 'date_issued_dt', label: 'Issue Date'
     config.add_index_field 'issue_no_t', label: 'Issue'
     config.add_index_field 'page_no_t', label: 'Page No'
-    config.add_index_field 'sequence_i', label: 'Page Order'
+    config.add_index_field 'sequence', label: 'Page Order'
     config.add_index_field 'full_text_txt', label: 'Page Text' ,highlight: true
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field 'issue_no_t', label: 'Issue'
-    config.add_show_field 'issue_date_display', label: 'Date'
+    config.add_show_field 'date_issued_display', label: 'Date'
     config.add_show_field 'page_no_t', label: 'Page No'
-    config.add_show_field 'sequence_i', label: 'Page Order'
+    config.add_show_field 'sequence', label: 'Page Order'
     config.add_show_field 'full_text_txt', label: 'Page Text'
 
     config.add_show_field 'next_page_link', label: 'Next Page Link'
@@ -195,7 +195,7 @@ class CatalogController < ApplicationController
     config.autocomplete_enabled = true
     config.autocomplete_path = 'suggest'
 
-    config.show.route = { controller: 'catalog', action: 'browse_issue_page' }
+    config.show.route = { controller: 'catalog', action: 'show' }
     # binding.pry
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
   end
 
   def hathitrust_image_src(document, **kw)
-    barcode = document.fetch('hathitrust_t').first
+    barcode = document.fetch('ht_barcode')
 
     img_link = document.fetch('img_link_t').first
 
@@ -38,14 +38,14 @@ module ApplicationHelper
   end
 
   def hathitrust_image(document, **kw)
-    barcode = document.fetch('hathitrust_t').first
-    return fake_image(document) if barcode != 'mdp.39015071754159'
+    namespace = document.fetch('ht_namespace')
+    return fake_image(document) if namespace == 'fake'
     %Q{<img src="#{hathitrust_image_src(document, **kw)}" />}.html_safe
   end
 
   def hathitrust_thumbnail(document, **kw)
-    barcode = document.fetch('hathitrust_t').first
-    return fake_image(document, kw.fetch(:size, ',250')) if barcode != 'mdp.39015071754159'
+    namespace = document.fetch('ht_namespace')
+    return fake_image(document, kw.fetch(:size, ',250')) if namespace == 'fake'
     %Q{<img src="#{hathitrust_thumbnail_src(document, **kw)}" />}.html_safe
   end
 
@@ -55,12 +55,13 @@ module ApplicationHelper
 
   require 'ffaker'
   def fake_image(document, size=nil)
-    barcode = document.fetch('hathitrust_t').first
-    text_link = document.fetch('text_link_t').first
+    namespace = document.fetch('ht_namespace')
+    barcode = document.fetch('ht_barcode')
+    text_link = document.fetch('text_link')
     issue_no = document.fetch("issue_no_t").first
-    page_sequence = document.fetch("sequence_i")
-    key = barcode + "/" + text_link
-    bgcolor = Rails.cache.fetch("#{barcode}/bgcolor") do
+    page_sequence = document.fetch("sequence")
+    key = namespace + "." + barcode + "/" + text_link
+    bgcolor = Rails.cache.fetch("#{namespace}.#{barcode}/bgcolor") do
       # [ 'sky', 'vine', 'lava', 'gray', 'industrial', 'social' ].sample
       "#%06x" % rand(0..0xffffff)
     end
@@ -69,6 +70,8 @@ module ApplicationHelper
       return holder_tag "110x150", text, nil, {}, { bg: bgcolor }
     elsif size == ",250"
       return holder_tag "187x250", text, nil, {}, { bg: bgcolor }
+    elsif size == '200,'
+      return holder_tag "200x270", text, nil, {}, { bg: bgcolor }
     else
       # text = Rails.cache.fetch(key) do
       #   FFaker::CheesyLingo.sentence

--- a/app/indexers/page_indexer.rb
+++ b/app/indexers/page_indexer.rb
@@ -8,13 +8,14 @@ class PageIndexer
 
   def generate_solr_doc(issue_doc)
 
-    full_text = get_full_text(issue_doc[:hathitrust_t], @page.text_link)
+    full_text = get_full_text(issue_doc, @page.text_link)
     page_id = "#{issue_doc[:id]}-#{@page.sequence}"
     solr_doc = { 
       id: page_id, # @page.id,
-      page_no_t:@page.page_no, sequence_i: @page.sequence,
-      text_link_t: @page.text_link, 
-      img_link_t: @page.img_link, 
+      page_no_t:@page.page_no, 
+      sequence: @page.sequence,
+      text_link: @page.text_link, 
+      img_link: @page.img_link, 
       full_text_txt:full_text,
       prev_page_link: nil,
       next_page_link: nil,
@@ -25,7 +26,17 @@ class PageIndexer
     }
 
     current_index = issue_doc[:pages].index { |v| v[0] == @page.id }
-    [:issue_date_display, :issue_no_t, :issue_date_dt, :issue_id_t, :hathitrust_t].each do |key|
+    [ :date_issued_display, 
+      :issue_no_t,
+      :issue_sequence,
+      :date_issued_dt, 
+      :issue_id_t, 
+      :date_issued_link,
+      :ht_namespace,
+      :ht_barcode,
+      :publication_link,
+      :publication_label
+    ].each do |key|
       solr_doc[key] = issue_doc[key]
     end
 
@@ -49,10 +60,10 @@ class PageIndexer
     conn.add solr_doc
   end
 
-  def get_full_text(issue_hathitrust, text_link)
+  def get_full_text(issue_doc, text_link)
     File.read(Rails.root.join(
       Rails.configuration.text_root, 
-      issue_hathitrust, 
+      "#{issue_doc[:ht_namespace]}.#{issue_doc[:ht_barcode]}", 
       text_link+'.txt'))
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,3 +1,14 @@
 class Issue < ActiveRecord::Base
   self.table_name = "issues"
+
+  belongs_to :publication
+  has_many :pages, -> { order(:sequence) }, dependent: :destroy
+
+  def slug(complete=true)
+    retval = self.date_issued
+    if complete or self.issue_sequence > 1
+      retval = "#{retval}_#{self.issue_sequence}"
+    end
+    retval
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,13 +1,14 @@
 class Page < ActiveRecord::Base
   self.table_name = "pages"
+
   before_destroy :remove_from_index
 
-  #attr_accessible :issue_id, page_no, sequence, text_link, img_link
+  belongs_to :issue
 
   def remove_from_index
     conn = Blacklight.default_index.connection 
     conn.delete_by_id(self.id)
-    conn.commit
+    conn.commit unless Rails.configuration.batch_commit
   end
 
   def get_full_text(issue, text_link)

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -1,0 +1,4 @@
+class Publication < ActiveRecord::Base
+
+  has_many :issues, -> { order(:date_issued, :issue_sequence) }, dependent: :destroy
+end

--- a/app/views/catalog/_index_grid.html.erb
+++ b/app/views/catalog/_index_grid.html.erb
@@ -1,5 +1,5 @@
 <div>
-    <%= link_to hathitrust_thumbnail(document, size: '200,'), document %>
+    <%= link_to hathitrust_thumbnail(document, size: '200,'), url_for_document(document) %>
     <div class="caption">
         <%= render_document_partials document, blacklight_config.view_config(:grid).partials, document_counter: document_counter %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  get 'browse/:issue_date/:sequence' => 'catalog#browse_issue_page', as: :browse_issue_page
+  get 'pub/:publication_link/:ht_barcode/:date_issued_link/:sequence' => 'catalog#show', as: :in_context
   
   mount Blacklight::Engine => '/'
   root to: "catalog#index"

--- a/db/migrate/20160413200000_create_publications.rb
+++ b/db/migrate/20160413200000_create_publications.rb
@@ -1,0 +1,12 @@
+class CreatePublications < ActiveRecord::Migration
+  def change
+    create_table :publications do |t|
+      t.string :title
+      t.string :slug
+      t.string :info_link
+
+      t.timestamps null: false      
+    end
+    add_index :publications, :slug, unique: true
+  end
+end

--- a/db/migrate/20160413202246_add_issues.rb
+++ b/db/migrate/20160413202246_add_issues.rb
@@ -2,18 +2,21 @@
 class AddIssues < ActiveRecord::Migration
   def self.up      
     create_table :issues do |t|
-      t.string  :hathitrust  #hathitrust id
+      t.string  :ht_namespace  #hathitrust namespace
+      t.string  :ht_barcode    #hathitrust barcode
       t.string  :volume      #volume number
       t.string  :issue_no    #issue number
       t.string  :edition     #edition number
       t.string  :date_issued #date issued
-      t.string  :newspaper   #newspaper title
+      t.integer :issue_sequence, default: 1 # track date_issued within barcode      
       t.integer :pages_count #track page associated with this issue
 
       t.timestamps null: false
+      t.belongs_to(:publication, foreign_key: true)
     end
 
     add_index :issues, :id
+    add_index :issues, :publication_id
   end
 
   def self.down

--- a/db/migrate/20160413202258_add_pages.rb
+++ b/db/migrate/20160413202258_add_pages.rb
@@ -1,13 +1,16 @@
 class AddPages < ActiveRecord::Migration
   def self.up
     create_table :pages do |t|
-      t.integer  :issue_id  #foreign key to issue table
+      # t.integer  :issue_id  #foreign key to issue table
       t.string   :page_no   #page number; not always found
       t.integer  :sequence  #sequence number to show page order
       t.string   :text_link #link for full text
+      t.string   :coordinates_link #link for full text
       t.string   :img_link  #image link
 
       t.timestamps null: false
+      t.belongs_to(:issue, foreign_key: true)
+
     end
 
     add_index :pages, :id # using id which is auto generated

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,30 +26,44 @@ ActiveRecord::Schema.define(version: 20160413202258) do
   add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id"
 
   create_table "issues", force: :cascade do |t|
-    t.string   "hathitrust"
+    t.string   "ht_namespace"
+    t.string   "ht_barcode"
     t.string   "volume"
     t.string   "issue_no"
     t.string   "edition"
     t.string   "date_issued"
-    t.string   "newspaper"
+    t.integer  "issue_sequence", default: 1
     t.integer  "pages_count"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "publication_id"
   end
 
   add_index "issues", ["id"], name: "index_issues_on_id"
+  add_index "issues", ["publication_id"], name: "index_issues_on_publication_id"
 
   create_table "pages", force: :cascade do |t|
-    t.integer  "issue_id"
     t.string   "page_no"
     t.integer  "sequence"
     t.string   "text_link"
+    t.string   "coordinates_link"
     t.string   "img_link"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.integer  "issue_id"
+  end
+
+  add_index "pages", ["id"], name: "index_pages_on_id"
+
+  create_table "publications", force: :cascade do |t|
+    t.string   "title"
+    t.string   "slug"
+    t.string   "info_link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "pages", ["id"], name: "index_pages_on_id"
+  add_index "publications", ["slug"], name: "index_publications_on_slug", unique: true
 
   create_table "searches", force: :cascade do |t|
     t.text     "query_params"

--- a/lib/fishrappr/search_state.rb
+++ b/lib/fishrappr/search_state.rb
@@ -6,7 +6,12 @@ module Fishrappr
           blacklight_config.show.route and
           (!doc.respond_to?(:to_model) or doc.to_model.is_a? SolrDocument)
         # route = blacklight_config.show.route.merge(action: :show, id: doc).merge(options)
-        route = blacklight_config.show.route.merge(issue_date: doc.fetch('issue_date_dt').split('T')[0], sequence: doc.fetch('sequence_i')).merge(options)
+        route = blacklight_config.show.route.merge(
+          publication_link: doc.fetch('publication_link'),
+          ht_barcode: doc.fetch('ht_barcode'),
+          date_issued_link: doc.fetch('date_issued_link'),
+          sequence: doc.fetch('sequence')
+          ).merge(options)
         route.delete(:id)
         route[:controller] = params[:controller] if route[:controller] == :current
         route

--- a/lib/tasks/populate_fake_data.rake
+++ b/lib/tasks/populate_fake_data.rake
@@ -30,10 +30,17 @@ unless Rails.env.production?
   def fake_setup(dates_filename)
     Page.destroy_all
 
+    publication = Publication.find_or_create_by(slug: 'the-daily-standup') do |publication|
+      publication.title = "The Daily Standup"
+      publication.info_link = "https://github.com/mlibrary/fishrappr"
+    end
+
     volume_idx = {}
 
     Rails.configuration.batch_commit = true
     Rails.configuration.index_enabled = false
+
+    possible_dates = []
 
     File.open(dates_filename).each do |line|
       line.strip!
@@ -45,54 +52,66 @@ unless Rails.env.production?
         STDERR.puts "#{line} : #{e}"
         next
       end
+      possible_dates << line
+    end
 
-      STDERR.puts line
+    possible_dates.each_slice(100) do |barcode_dates|
+
+      ht_namespace = "fake"
+      # logged for curiosity: sprintf("%014d", rand(1e9..1e10).to_i)
+      ht_barcode = (1..14).map{"0123456789".chars.to_a.sample}.join
+
+      ht_path = "./tmp/fake_data/#{ht_namespace}.#{ht_barcode}"
+      if not Dir.exists?(ht_path)
+        Dir.mkdir(ht_path)
+      end
 
       t0 = Time.now
 
-      volume = line.split('-')[1]
-      issue_no = volume_idx.fetch(volume, 0) + 1
-      volume_idx[volume] = issue_no
+      barcode_dates.each_with_index do |date_issued|
 
-      pages_count = rand(15)
-      hathitrust = "mdp.#{FFaker::IdentificationESCO.drivers_license}"
+        volume = date_issued.split('-')[1]
+        issue_no = volume_idx.fetch(volume, 0) + 1
+        volume_idx[volume] = issue_no
 
-      # make an issue
-      issue = Issue.create(
-        hathitrust: hathitrust,
-        volume: volume,
-        date_issued: line,
-        issue_no: issue_no.to_s,
-        pages_count: pages_count,
-        newspaper: "Michigan Daily",
-      )
+        pages_count = rand(25)
 
-      (1 .. pages_count ).each do |seq|
-        # make a new text file
-        text_file_id = "TXT#{'%08d' % seq}"
-        image_file_id = "IMAGE#{'%08d' % seq}"
-
-        if not Dir.exists?("./tmp/fake_data/#{hathitrust}")
-          Dir.mkdir("./tmp/fake_data/#{hathitrust}")
-        end
-
-        File.open("./tmp/fake_data/#{hathitrust}/#{text_file_id}.txt", 'w') do |io|
-          io.puts FFaker::CheesyLingo.paragraph
-          io.puts FFaker::CheesyLingo.paragraph
-        end
-
-        page = Page.create(
-          issue_id: issue.id,
-          page_no: seq.to_s,
-          sequence: seq,
-          text_link: text_file_id,
-          img_link: image_file_id,
+        # make an issue
+        issue = Issue.create(
+          ht_namespace: ht_namespace,
+          ht_barcode: ht_barcode,
+          publication_id: publication.id,
+          volume: volume,
+          date_issued: date_issued,
+          issue_no: issue_no.to_s,
+          pages_count: pages_count,
         )
 
-      end
+        (1 .. pages_count ).each do |seq|
+          # make a new text file
+          text_file_id = "TXT#{'%08d' % seq}"
+          image_file_id = "IMAGE#{'%08d' % seq}"
 
-      # Blacklight.default_index.connection.commit
-      STDERR.puts "-- #{line} : #{Time.now - t0}"
+
+          File.open("#{ht_path}/#{text_file_id}.txt", 'w') do |io|
+            io.puts FFaker::CheesyLingo.paragraph
+            io.puts FFaker::CheesyLingo.paragraph
+          end
+
+          page = Page.create(
+            issue_id: issue.id,
+            page_no: seq.to_s,
+            sequence: seq,
+            text_link: text_file_id,
+            img_link: image_file_id,
+          )
+
+        end
+
+        # Blacklight.default_index.connection.commit
+        STDERR.puts "-- #{ht_barcode} : #{date_issued} : #{Time.now - t0}"
+
+      end
 
     end
   end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -532,8 +532,14 @@
 
    <!-- from curation concerns -->
    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
+
+   <!-- for fishrappr -->
+   <dynamicField name="ht_*" type="string" stored="true" indexed="true" multiValued="false"/>
+   <dynamicField name="*_id" type="string" stored="true" indexed="true" multiValued="false"/>
    <dynamicField name="*_link" type="string" stored="true" indexed="true" multiValued="false"/>
    <dynamicField name="*_label" type="string" stored="true" indexed="false" multiValued="false"/>
+   <field name="sequence" type="int" indexed="true" stored="true" required="false" />
+   <field name="issue_sequence" type="int" indexed="true" stored="true" required="false" />
 
    <!-- uncomment the following to ignore any fields that don't already match an existing 
         field name or dynamic field, rather than reporting them as an error. 

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Publication, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Adding support for publications (#60,61,62,63)

index supports tracking publisher; references to issue_date > date_issued; url_for_document uses proposed hierarchical route

issue_date facet should be date_issued

adjust sequence facets

schema.xml has fields specifically for fishrappr (multivalued fields cannot be used for sort).

Closes: #60, #61, #62, #63, #64