### PR TITLE
fixes for highlighting

### DIFF
--- a/app/assets/javascripts/toggle_highlighting.js
+++ b/app/assets/javascripts/toggle_highlighting.js
@@ -1,5 +1,9 @@
 $().ready(function() {
 
+    if ( ! $("body").is(".blacklight-catalog-show") ) {
+        return;
+    }
+
     var $content = $("#content");
     var $map = $("#map");
     var $action = $(".action-toggle-highlight");

--- a/app/controllers/concerns/fishrappr/catalog.rb
+++ b/app/controllers/concerns/fishrappr/catalog.rb
@@ -225,7 +225,7 @@ module Fishrappr::Catalog
     end
 
     def highlights_visible?
-      session[:show_highlight]
+      ! ( session[:show_highlight] == false )
     end
 
 end


### PR DESCRIPTION
- only emply highlight script on show pages
- assume initial state is to show highlights

Addresses part of  #122 