### PR TITLE
Update views: simplify, reduce. And highlighting: complexify, obtuse

### DIFF
--- a/app/assets/javascripts/leaflet.remote_zoom.js
+++ b/app/assets/javascripts/leaflet.remote_zoom.js
@@ -81,6 +81,8 @@
             var per = Math.ceil(( map._zoom / map.getMaxZoom() ) * 100.0);
             this._zoomStatusField.text(per + "%");
 
+            $(".span-zoom-level").text(map._zoom);
+
             if (map._zoom === map.getMinZoom()) {
                 L.DomUtil.addClass(this._zoomOutButton, className);
             }

--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -5,8 +5,8 @@
 @import 'blacklight/blacklight';
 
 .highlight {
-    background-color: #FF9632;
-    background-color: rgba(255, 150, 50, 0.5);
+    background-color: #4C7ED1;
+    background-color: rgba(76, 126, 209, 0.4);
     font-weight: bold;
 
     &.de-highlighted {
@@ -17,7 +17,7 @@
 
 .grid .highlight {
     // background-color: blue;
-    background-color: #FF9632;
+    background-color: #4C7ED1;
     position: absolute;
 
     // min-width: 15px;
@@ -30,4 +30,16 @@
     display: inline-block;
     width: 200px;
     height: auto;
+}
+
+#documents h3 {
+    margin-top: 0;
+}
+
+.caption h3 {
+    font-size: inherit;
+}
+
+#documents .row {
+    margin-bottom: 2em;
 }

--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -4,6 +4,14 @@ html, body {
 
 #map {
     height: 90%;
-    border: 1px dotted #ddd;
+
+    &:focus {
+        outline: auto 5px -webkit-focus-ring-color;
+    }
 }
 
+article {
+    font-size: 1.2em;
+    line-height: 1.7em;
+    max-width: 35em;
+}

--- a/app/controllers/concerns/fishrappr/catalog.rb
+++ b/app/controllers/concerns/fishrappr/catalog.rb
@@ -188,8 +188,8 @@ module Fishrappr::Catalog
     if document.highlight_field('page_text')
       non_lexemes = Regexp.new("^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$|'s$")
       document.highlight_field('page_text').each do |text|
-        text.scan(/<span class="highlight">.+?<\/span>/).each do |word|
-          word.gsub!('<span class="highlight">', '').gsub!('</span>', '')
+        text.scan(/\[\[\[\[.+?\]\]\]\]/).each do |word|
+          word.gsub!('[[[[', '').gsub!(']]]]', '')
           word = word.gsub(non_lexemes, '')
           next unless word.strip and words[word.strip].nil?
           words[word.strip.downcase] = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,9 +63,12 @@ module ApplicationHelper
     image_width = document.fetch('image_width_ti')
     size = kw.fetch(:size, ',250')
     width, height = size.split(',')
-    if width != ""
+    if not width.blank?
       width = width.to_i
       height = ( image_height * ( width.to_f / image_width ) ).to_i
+    else
+      height = height.to_i
+      width = ( image_width * ( height.to_f / image_height ) ).to_i
     end
 
     # { 'min-width' => width, 'min-height' => height }
@@ -88,13 +91,13 @@ module ApplicationHelper
   # TO DO: Needs to be moved into a style using a data attribute
   def hathitrust_background_thumbnail(document, **kw)
     namespace = document.fetch('ht_namespace')
-    tn = "style=\'background-image: url(\""
+    tn = "style=\'background: url(\""
     if namespace == 'fake'
       tn += "#{image_url("fake_image.png")}"
     else
       tn += "#{hathitrust_thumbnail_src(document, **kw)}"
     end
-    tn += "\");\'"
+    tn += "\") top left no-repeat;\'"
     tn.html_safe
   end
 
@@ -112,16 +115,19 @@ module ApplicationHelper
     return @document["page_text"].first 
   end
 
-  def render_plain_text(document, field)
+  def render_plain_text(document, field, breaks=true)
     retval = []
     texts = document.has_highlight_field?(field) ? document.highlight_field(field) : document.fetch(field)
+    prefix = breaks ? '' : '&#8230;'.html_safe
     retval = ActiveSupport::SafeBuffer.new
     Array(texts).each do |text|
       next if text.strip.blank?
       retval << '<p>'.html_safe
-      retval << text.gsub("\n", " ")
+      retval << prefix + text + prefix # .gsub("\n", " ")
       retval << '</p>'.html_safe
     end
+    retval.gsub!(/\n\n+/, "\n\n")
+    retval.gsub!(/\n/, breaks ? "<br />\n".html_safe : " ")
     (retval.gsub('[[[[', '<span class="highlight">'.html_safe).gsub(']]]]', '</span>'.html_safe)).html_safe
   end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,10 @@
 <% # container for a single doc -%>
-<div class="document <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
-  <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter %>
+<div class="row" data-words="<%= process_highlighted_words(document) %>">
+    <div class="col-md-9 col-md-push-3">
+        <%= render partial: '/catalog/index_default.html', locals: { document: document } %>
+    </div>
+    <div class="col-md-3 col-md-pull-9">
+        <%= link_to hathitrust_thumbnail(document, size: ',250'), url_for_document(document), { class: 'thumbnail', style: hathitrust_thumbnail_style(document, size: ',250') } %>
+    </div>
 </div>
+    

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -1,0 +1,12 @@
+<h3>
+    <% dochead = capture do %>
+        <%= render_index_field_value document, field: :date_issued_display %>
+        &#8226;
+        Issue 
+        <%= render_index_field_value document, field: :issue_no_t %>
+        &#8226;
+        Image 
+        <%= render_index_field_value document, field: :sequence %>
+    <% end %>
+    <%= link_to_document document, dochead %>
+</h3>

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,0 +1,4 @@
+<% # container for all documents in index list view -%>
+<div id="documents" class="documents-<%= document_index_view_type %> container-fluid">
+  <%= render documents, :as => :document %>
+</div>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,13 +1,3 @@
 <%# default partial to display solr document fields in catalog index view -%>
-<span class="document-metadata">
-  <% dochead = capture do %>
-    <% index_fields(document).each do |field_name, field| -%>
-      <% if ((should_render_index_field? document, field) && field_name.parameterize != "page_text") %>
-        <span class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></span>
-        <span class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_value document, field: field_name %>&nbsp&nbsp</span>
-      <% end -%>
-    <% end -%>
-  <% end %>
-  <%= link_to_document document, dochead %>
-</span>
-<%= render_plain_text(document, 'page_text') %>
+<%= render partial: 'catalog/document_header', locals: { document: document } %>
+<%= render_plain_text(document, 'page_text', false) %>

--- a/app/views/catalog/_index_grid.html.erb
+++ b/app/views/catalog/_index_grid.html.erb
@@ -1,6 +1,6 @@
 <div data-words="<%= process_highlighted_words(document) %>" data-identifier="<%= document.id %>">
     <%= link_to hathitrust_thumbnail(document, size: '200,'), url_for_document(document), { class: 'thumbnail', style: hathitrust_thumbnail_style(document, size: '200,') } %>
     <div class="caption">
-        <%= render_document_partials document, blacklight_config.view_config(:grid).partials, document_counter: document_counter %>
+        <%= render partial: 'catalog/document_header', locals: { document: document } %>
     </div>
 </div>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,1 +1,5 @@
-<h2><%= document['date_issued_display'].first %></h2>
+<h2>
+    <%= document['date_issued_display'].first %>
+     - 
+     Issue <%= document['issue_no_t'].first %>
+</h2>

--- a/app/views/catalog/_show_image.html.erb
+++ b/app/views/catalog/_show_image.html.erb
@@ -15,10 +15,26 @@
             center: [0, 0],
             crs: L.CRS.Simple,
             zoom: 0,
-            zoomControl: false
+            zoomControl: false,
+            scrollWheelZoom: false
           });
 
           map.addControl(new L.Control.RemoteZoom());
+
+          var min_opacity = 40;
+          var max_opacity = 80;
+          map.on('zoomend', function(e) {
+            var zoom = this._zoom;
+            var opacity = min_opacity + ( ( map.getMaxZoom() - zoom ) * 10.0 );
+            if ( opacity > max_opacity ) { opacity = max_opacity; }
+            opacity /= 100.0;
+            annoFeatures.setStyle({ fillOpacity: opacity, opacity: opacity });
+            // if ( zoom > 4.0 ) {
+            //   annoFeatures.setStyle({ fillOpacity: 0.4, opacity: 0.4 });
+            // } else {
+            //   annoFeatures.setStyle({ fillOpacity: 0.8, opacity: 0.8 });
+            // }
+          })
 
           F.map = map;
           var baseLayer;
@@ -39,7 +55,10 @@
             }
 
             var highlightColor;
-            highlightColor = '#24AAE1';
+            var opacity;
+            // highlightColor = '#D14C4C';
+            highlightColor = '#4C7ED1'; // #24AAE1';
+            opacity = 0.90;
             // highlightColor = '#FF9632';
 
             initialZoom = baseLayer._getInitialZoom(map.getSize());
@@ -51,13 +70,26 @@
                 var content = value.resource.chars;
                 if ( words.indexOf(content) < 0 ) { return ; }
                 var b = /xywh=(.*)/.exec(value.on)[1].split(',');
-                var minPoint = L.point(b[0], b[1]);
-                var maxPoint = L.point(parseInt(b[0]) + parseInt(b[2]), parseInt(b[1]) + parseInt(b[3]));
+                // var minPoint = L.point(b[0], b[1]);
+                // var maxPoint = L.point(parseInt(b[0]) + parseInt(b[2]), parseInt(b[1]) + parseInt(b[3]));
+
+                var h = parseFloat(b[3]) * 1.5;
+                var w = parseFloat(b[2]) * 1.10;
+
+                var dw = ( w - parseFloat(b[2]) ) / 2;
+                var dh = ( h - parseFloat(b[3]) ) / 2;
+
+                // var minPoint = L.point(parseInt(b[0] - dw), parseInt(b[1] - dh));
+                // var maxPoint = L.point(parseInt(b[0] - dw) + parseInt(w) + dw, parseInt(b[1] - dh) + parseInt(h) + dh);
+
+                var minPoint = L.point(parseFloat(b[0] - dw), parseFloat(b[1] - dh));
+                var maxPoint = L.point(parseFloat(b[0] - dw) + parseFloat(w) + dw, parseFloat(b[1] - dh) + parseFloat(h) + dh);
+
                 var min = map.unproject(minPoint, maxZoom);
                 var max = map.unproject(maxPoint, maxZoom);
-                console.log(min, max, value.resource.chars);
+
                 // clickable: true enables hover of label text
-                annoFeatures.addLayer(L.rectangle(L.latLngBounds(min, max), { color: highlightColor, weight: 1, clickable: false }).bindLabel(value.resource.chars));
+                annoFeatures.addLayer(L.rectangle(L.latLngBounds(min, max), { color: highlightColor, fillColor: highlightColor, fill: true, weight: 2.5, opacity: opacity, fillOpacity: opacity, clickable: false }).bindLabel(value.resource.chars));
               });
               if ( $("#content").data('highlighting') ) {
                 annoFeatures.addTo(map);

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -6,6 +6,7 @@
     <% if @subview == 'plaintext' %>
       <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
     <% else %>
+      <%= render partial: 'catalog/show_header_default', locals: { document: @document } %>
       <%= render 'catalog/show_image' %>
     <% end %>
   </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -9,8 +9,11 @@
    <% end %>
 
    <div class="list-group">
-    <a href="?view=plaintext" class="list-group-item <%= @subview == 'plaintext' ? 'active' : '' %>">View Plain Text</a>
-    <a href="?view=image" class="list-group-item <%= @subview == 'image' ? 'active' : '' %>">View Scanned Image</a>
+    <% if @subview == 'image' %>
+      <a href="?view=plaintext" class="list-group-item <%= @subview == 'plaintext' ? 'active' : '' %>">View Plain Text</a>
+    <% else %>
+      <a href="?view=image" class="list-group-item <%= @subview == 'image' ? 'active' : '' %>">View Scanned Image</a>
+    <% end %>
     <% if highlights_available? %>
       <% if highlights_visible? %>
         <a href="#" class="list-group-item action-toggle-highlight">Remove Hit Highlights</a>
@@ -25,13 +28,14 @@
 <div id="content" class="<%= show_content_classes %>" data-words="<%= process_highlighted_words(@document) %>" data-identifier="<%= @document.id %>" data-highlighting="<%= highlights_visible? ? 'true' : 'false' %>">
   <div class="pagination-search-widgets">
     <% if @subview == 'image' %>
-    <nav class="pull-left">
+    <div class="pull-left">
       <ul class="pager">
-        <li><button class="btn btn-default action-zoom-in"><%= raw(t('views.issue.zoom_in')) %></button></li>
+        <li><span class="span-zoom-level bg-info">0</span></li>
         <li><span class="span-zoom-status">100%</span></li>
+        <li><button class="btn btn-default action-zoom-in"><%= raw(t('views.issue.zoom_in')) %></button></li>
         <li><button class="btn btn-default action-zoom-out"><%= raw(t('views.issue.zoom_out')) %></button></li>
       </ul>
-    </nav>
+    </div>
     <% end %>
 
     <nav class="pull-right">


### PR DESCRIPTION
Views:

- zoom toolbar rearranged based on fultonis feedback
- disable scroll-to-zoom
- indicate focus on image viewer
- render OCR with line breaks + larger font = increased legibility (per futonis)
- begin simplifying layout of list results

Highlighting:

- standardize on #4C7ED1 at 40% for read-through-highlighting
- image highlighting gets less opaque as you zoom in

Temporarily:

- display leaflet zoom level in zoom toolbar

