### PR TITLE
round of edit to views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'therubyracer', platforms: :ruby
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 
+gem 'nestive'
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     mysql2 (0.4.4)
+    nestive (0.6.0)
+      rails (>= 3.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
@@ -295,6 +297,7 @@ DEPENDENCIES
   jquery-rails
   mail_form
   mysql2
+  nestive
   pry-byebug
   pry-rails
   puma

--- a/app/assets/javascripts/leaflet-iiif.js
+++ b/app/assets/javascripts/leaflet-iiif.js
@@ -290,12 +290,12 @@ L.TileLayer.Iiif = L.TileLayer.extend({
 
     for (var i = _this.maxNativeZoom; i >= 0; i--) {
       imageSize = this._imageSizes[i];
-      if (imageSize[key] * tolerance < mapSize[key] ) {
+      if (imageSize[key] < ( mapSize[key] - tolerance )) {
         // console.log("INITIAL ZOOM", i, imageSize[key], this._imageSizes[i + 1][key], mapSize[key], key);
         var d = imageSize[key];
         var j = 0;
         // console.log(d, j, i + j );
-        while ( d * ( 1.0 + j ) < mapSize[key] ) {
+        while ( d * ( 1.0 + j ) < (mapSize[key] - tolerance) ) {
           j += ( 0.0625 / 2 );
           // console.log(d, j, i + j, d * ( 1.0 + j ) * tolerance, mapSize[key] );
         }
@@ -312,6 +312,7 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     // return a default zoom
     return 2;
   },
+
   _getInitialZoomXX: function (mapSize) {
     var _this = this,
       tolerance = 0.8,

--- a/app/assets/javascripts/leaflet.remote_zoom.js
+++ b/app/assets/javascripts/leaflet.remote_zoom.js
@@ -79,9 +79,11 @@
             L.DomUtil.removeClass(this._zoomOutButton, className);
 
             var per = Math.ceil(( map._zoom / map.getMaxZoom() ) * 100.0);
-            this._zoomStatusField.text(per + "%");
 
-            $(".span-zoom-level").text(map._zoom);
+            var status = '';
+            status += map._zoom + " / ";
+            status += per + '%';
+            this._zoomStatusField.text(status);
 
             if (map._zoom === map.getMinZoom()) {
                 L.DomUtil.addClass(this._zoomOutButton, className);

--- a/app/assets/javascripts/page_image_viewer.js
+++ b/app/assets/javascripts/page_image_viewer.js
@@ -1,0 +1,123 @@
+  $().ready(function() {
+      
+    if ( ! $("body").is(".blacklight-catalog-show") ) {
+      return;
+    }
+
+    window.F = window.F || {};
+    var $map = $("#image-viewer");
+    // $map.height($(window).height() - 100);
+
+    var words = $map.data('words');
+    var identifier = $map.data('identifier');
+
+    var map;
+    map = L.map($map.get(0), {
+      center: [0, 0],
+      crs: L.CRS.Simple,
+      zoom: 0,
+      zoomControl: false,
+      scrollWheelZoom: false,
+      attributionControl: false
+    });
+
+    map.addControl(new L.Control.RemoteZoom());
+
+    var min_opacity = 40;
+    var max_opacity = 80;
+    map.on('zoomend', function(e) {
+      var zoom = this._zoom;
+      var opacity = min_opacity + ( ( map.getMaxZoom() - zoom ) * 10.0 );
+      if ( opacity > max_opacity ) { opacity = max_opacity; }
+      opacity /= 100.0;
+      annoFeatures.setStyle({ fillOpacity: opacity, opacity: opacity });
+      // if ( zoom > 4.0 ) {
+      //   annoFeatures.setStyle({ fillOpacity: 0.4, opacity: 0.4 });
+      // } else {
+      //   annoFeatures.setStyle({ fillOpacity: 0.8, opacity: 0.8 });
+      // }
+    })
+
+    F.map = map;
+    var baseLayer;
+    var page;
+    var annoFeatures = new L.FeatureGroup();
+    F.annoFeatures = annoFeatures;
+
+    var imageHeight; var imageWidth;
+    //map.addLayer(annoFeatures);
+
+    var loadAnnotations = function(e) {
+      var baseLayer = e.target;
+      baseLayer.off('load');
+
+      // just in case, don't do anything if there are no words
+      if ( words.length == 0 ) {
+        return;
+      }
+
+      var highlightColor;
+      var opacity;
+      // highlightColor = '#D14C4C';
+      highlightColor = '#4C7ED1'; // #24AAE1';
+      opacity = 0.90;
+      // highlightColor = '#FF9632';
+
+      initialZoom = baseLayer._getInitialZoom(map.getSize());
+      var maxZoom = map.getMaxZoom();
+      console.log(map.getZoom(), baseLayer.maxNativeZoom, map.getMaxZoom(), initialZoom, maxZoom);
+      $.getJSON(page.otherContent[0]['@id'], function(annoData) {
+
+        $.each(annoData.resources, function(i, value) {
+          var content = value.resource.chars;
+          if ( words.indexOf(content) < 0 ) { return ; }
+          var b = /xywh=(.*)/.exec(value.on)[1].split(',');
+          // var minPoint = L.point(b[0], b[1]);
+          // var maxPoint = L.point(parseInt(b[0]) + parseInt(b[2]), parseInt(b[1]) + parseInt(b[3]));
+
+          var h = parseFloat(b[3]) * 1.5;
+          var w = parseFloat(b[2]) * 1.10;
+
+          var dw = ( w - parseFloat(b[2]) ) / 2;
+          var dh = ( h - parseFloat(b[3]) ) / 2;
+
+          // var minPoint = L.point(parseInt(b[0] - dw), parseInt(b[1] - dh));
+          // var maxPoint = L.point(parseInt(b[0] - dw) + parseInt(w) + dw, parseInt(b[1] - dh) + parseInt(h) + dh);
+
+          var minPoint = L.point(parseFloat(b[0] - dw), parseFloat(b[1] - dh));
+          var maxPoint = L.point(parseFloat(b[0] - dw) + parseFloat(w) + dw, parseFloat(b[1] - dh) + parseFloat(h) + dh);
+
+          var min = map.unproject(minPoint, maxZoom);
+          var max = map.unproject(maxPoint, maxZoom);
+
+          // clickable: true enables hover of label text
+          annoFeatures.addLayer(L.rectangle(L.latLngBounds(min, max), { color: highlightColor, fillColor: highlightColor, fill: true, weight: 2.5, opacity: opacity, fillOpacity: opacity, clickable: false }).bindLabel(value.resource.chars));
+        });
+        if ( $map.data('highlighting') ) {
+          annoFeatures.addTo(map);
+        }
+      })
+    }
+
+    var i = 1;
+    $.getJSON('/services/manifests/' + identifier, function(data) {
+      console.log(data);
+      page = data.sequences[0].canvases[0];
+      baseLayer = L.tileLayer.iiif(
+        page.images[0].resource.service['@id'] + '/info.json'
+      );
+
+      imageHeight = data.sequences[0].canvases[0].height;
+      imageWidth = data.sequences[0].canvases[0].width;
+
+      console.log(imageWidth, "x", imageHeight);
+      if ( true || words.length > 0 ) {
+        console.log("LOADING ANNOTATIONS");
+        baseLayer.on('load', loadAnnotations);
+      }
+        
+      baseLayer.addTo(map);
+
+    });
+
+  })

--- a/app/assets/javascripts/toggle_highlighting.js
+++ b/app/assets/javascripts/toggle_highlighting.js
@@ -4,8 +4,9 @@ $().ready(function() {
         return;
     }
 
-    var $content = $("#content");
-    var $map = $("#map");
+    var $content = $("[data-highlighting]");
+    var $text = $(".document");
+    var $map = $("#image-viewer");
     var $action = $(".action-toggle-highlight");
 
     $action.on('click', function(e) {
@@ -24,14 +25,14 @@ $().ready(function() {
             } else {
                 F.map.removeLayer(F.annoFeatures);
             }
-        } else {
-            $content.find("span.highlight").toggleClass("de-highlighted", ! status);
         }
+        $text.find("span.highlight").toggleClass("de-highlighted", ! status);
     }
 
     var toggle_label = function(status) {
         // maybe return label text in toggle response to have access to locales?
-        $action.text(status ? "Remove Hit Highlights" : "Show Hit Highlights");
+        // $action.text(status ? "Remove Hit Highlights" : "Show Hit Highlights");
+        $action.prop("checked", status);
     }
 
     if ( $map.length == 0 ) {

--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -1,0 +1,8 @@
+// $navbar-bgcolor: #00274C;
+$navbar-bgcolor: #E5E5E5;
+$footer-bgcolor: #323333;
+$header-bgcolor: #00274C;
+$body-bgcolor: #F2F2F2;
+
+$base-fonts: "Helvetica Neue", Helvetica, Arial, sans-serif;
+

--- a/app/assets/stylesheets/blacklight/_header.scss
+++ b/app/assets/stylesheets/blacklight/_header.scss
@@ -1,11 +1,8 @@
+@import "globals";
 #header-navbar {
-  background-color: #00274C;
-  .navbar-brand { 
-  	width: 150px;
-        height: 50px;
-	display: inline-block;
-        color: #FFF;
-        font: 25px arial, sans-serif;
-}
-
+  background-color: $header-bgcolor; // #00274C;
+  padding: 10px;
+  .navbar-brand {
+    font-size: 24px;
+  }
 }

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,4 +1,5 @@
 /* CONTACT FORM */
+@import "globals";
 
 .hidden { display: none; }
 
@@ -98,7 +99,7 @@ p.help-block {
 
 /* STYLES FOR SEARCH PARTIAL ON HOME AND CATALOG PAGE */
 
-body.blacklight-catalog-index, body.fishrappr {
+body.blacklight-catalog-index, body.blacklight-catalog-home {
 
     div.search {
       background-color: black;
@@ -440,7 +441,7 @@ body.blacklight-catalog-index {
 
 /* STYLES FOR HOME PAGE */
 
-body.fishrappr {
+body.blacklight-catalog-home {
   background-image: image-url("home_page_banner.png");
   background-position: 0 50px;
   background-repeat: repeat-x;
@@ -541,62 +542,85 @@ body.fishrappr {
 //   margin-bottom: 50px;  /* Margin bottom by footer height */
 // }
 
+html, body {
+  height: 100%;
+}
+
+body {
+    background: $body-bgcolor;
+}
+
+.navigation-toolbar {
+    background: $navbar-bgcolor;
+    margin-top: -20px;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
 footer { 
-  background-color: #00274C;
-  // bottom: 0;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  // margin-top: 50px;
+  border-radius: 0 !important;
+  padding: 10px;
+
+  &.navbar-inverse {
+    background-color: $footer-bgcolor;
+  }
+
+  font-family: $base-fonts;
   font-size: 14px;
-  height: 50px;
-  // position: absolute;
-  width: 100%;
 
-  ul, span.copyright {
-    list-style-type: none;
-    margin: 0;
-    margin-left: 2em;
-    overflow: hidden;
-    padding: 0;
-  }
-
-  li {
-    float: left;
-  }
-
-  li a, span.copyright {
-    color: white;
-    display: block;
-    margin: 4px;
-    margin-top: 6px;
-    padding: 7px;
-    text-align: center;
-    text-decoration: none;
-  }
-
-  li.footer-link-help a {
+  .footer-link-help a {
     border: 1px solid white;
   }
+  
+  // ul, span.copyright {
+  //   list-style-type: none;
+  //   margin: 0;
+  //   margin-left: 2em;
+  //   overflow: hidden;
+  //   padding: 0;
+  // }
 
-  li.footer-link-home a {
-    border: 1px solid #00274C;
-  }
+  // li {
+  //   float: left;
+  // }
 
-  li a, li a:visited {
-    float: left;
-    text-decoration: none;
-  }
+  // li a, span.copyright {
+  //   color: white;
+  //   display: block;
+  //   margin: 4px;
+  //   margin-top: 6px;
+  //   padding: 7px;
+  //   text-align: center;
+  //   text-decoration: none;
+  // }
 
-  li a:hover, li a:active {
-    color: white;
-    text-decoration: none;
-  }
+  // li.footer-link-help a {
+  //   border: 1px solid white;
+  // }
 
-  span.copyright {
-    border: 0;
-    display: block;
-    float: right;
-    margin: 0;
-    padding: 0;
-  }
+  // li.footer-link-home a {
+  //   border: 1px solid #00274C;
+  // }
+
+  // li a, li a:visited {
+  //   float: left;
+  //   text-decoration: none;
+  // }
+
+  // li a:hover, li a:active {
+  //   color: white;
+  //   text-decoration: none;
+  // }
+
+  // span.copyright {
+  //   border: 0;
+  //   display: block;
+  //   float: right;
+  //   margin: 0;
+  //   padding: 0;
+  // }
 }
 
 /* TOP NAV BAR */

--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -1,13 +1,81 @@
-html, body {
-  height: 100%;
+@import "globals";
+
+#image-viewer-wrap {
+    height: 75%;
+    padding-top: 45px;
+    margin-bottom: 20px;
+    background: black;
+    position: relative;
 }
 
-#map {
-    height: 90%;
+#image-viewer {
+
+    background: black;
+    height: 99%;
 
     &:focus {
         outline: auto 5px -webkit-focus-ring-color;
     }
+}
+
+.image-viewer-toolbar {
+    position: absolute;
+    top: 5px;
+    left: 0;
+    right: 0;
+    height: 30px;
+
+    div > span {
+        color: white;
+        display: inline-block;
+        padding: 5px 10px;
+        line-height: 18px;
+    }
+
+    .btn {
+        background: #9B9B9B;
+        color: white;
+        width: 100px;
+    }
+}
+
+.zoom-toolbar > span {
+    border: 1px solid white;
+    font-size: 12px;
+}
+
+.navbar .pager {
+    margin-top: 0;
+}
+
+.local-options-toolbar {
+    display: flex;
+    padding: 0;
+    // margin: -1em 0 0 -1em;
+}
+
+.local-options-toolbar .grid-col-md-4 {
+
+    flex: 1;
+
+    background: white;
+    padding: 1em;
+    margin-right: 1em;
+    &:last-child {
+        margin-right: 0;
+    }
+
+
+    // min-height: 150px;
+    // border-right: 8px solid #F2F2F2;
+    // &:last-child {
+    //     border-right: none;
+    // }
+}
+
+
+.blacklight-catalog-show h2 {
+    margin-top: 0;
 }
 
 article {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,8 @@ class CatalogController < ApplicationController
   include Fishrappr::Catalog
 
   before_action :setup_publication
+  layout :resolve_layout
+
 
   configure_blacklight do |config|
     # default advanced config values

--- a/app/controllers/concerns/fishrappr/catalog.rb
+++ b/app/controllers/concerns/fishrappr/catalog.rb
@@ -9,6 +9,7 @@ module Fishrappr::Catalog
     helper_method :process_highlighted_words
     helper_method :highlights_available?
     helper_method :highlights_visible?
+    helper_method :container_classes
   end
 
   def search_results(user_params)
@@ -54,6 +55,7 @@ module Fishrappr::Catalog
   def show
     search_params = current_search_session.try(:query_params)
     search_field = search_params ? search_params["q"] : nil
+    @raw_layout = true
     if params[:id] and search_field
       @response, @document = fetch_with_highlights params[:id], search_field
       # still fighting with blacklight to build the right kind of query
@@ -257,10 +259,14 @@ module Fishrappr::Catalog
         data[:pages].each do |page|
           zipfile.get_output_stream(page[:id]) { |f| f.puts page[:page_text] }
         end
-    }
-    send_file fname
+      }
+      send_file fname
     end
       
+    def container_classes
+      @container_fluid ? 'container-fluid' : 'container'
+    end
+
     def get_issue_data(flds=[])
       # need to find all the issues for this issue
       ht_namespace = @document.fetch('ht_namespace')
@@ -305,6 +311,15 @@ module Fishrappr::Catalog
         data[:pages] << datum
       end  
       data
+    end
+
+    def resolve_layout
+      case action_name
+      when "show"
+        "pageview"
+      else
+        "blacklight"
+      end
     end
 
      

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -4,7 +4,7 @@
         <%= render partial: '/catalog/index_default.html', locals: { document: document } %>
     </div>
     <div class="col-md-3 col-md-pull-9">
-        <%= link_to hathitrust_thumbnail(document, size: ',250'), url_for_document(document), { class: 'thumbnail', style: hathitrust_thumbnail_style(document, size: ',250') } %>
+        <%= link_to hathitrust_thumbnail(document, size: ',250'), url_for_document(document), { class: 'thumbnail' } %>
     </div>
 </div>
     

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,80 +1,113 @@
-<div id="sidebar" class="<%= show_sidebar_classes %>">
-   <%= render_document_sidebar_partial %>
-
-   <% if current_search_session %>
-    <div class="list-group">
-      <%= link_back_to_catalog class: 'list-group-item list-group-item-info' %>
-      <%=link_to t('blacklight.search.start_over'), start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'list-group-item' %>
+<%= replace :search_navbar do %>
+  <% if current_search_session %>
+    <div class="navigation-toolbar">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-md-6">
+            <%= link_back_to_catalog class: 'btn btn-info' %>
+            <%= link_to t('blacklight.search.start_over'), start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn btn-default' %>      
+          </div>
+        </div>
+      </div>
     </div>
-   <% end %>
+  <% end %>
+<% end %>
 
-  <div class="btn-group-vertical action-group" role="group">
-    <% if @subview == 'image' %>
-      <a href="?view=plaintext" class="btn btn-default">View Plain Text</a>
-    <% else %>
-      <a href="?view=image" class="btn btn-default">View Scanned Image</a>
-    <% end %>
-    <% if highlights_available? %>
-      <% if highlights_visible? %>
-        <a href="#" class="btn btn-default action-toggle-highlight">Remove Hit Highlights</a>
-      <% else %>
-        <a href="#" class="btn btn-default action-toggle-highlight">Show Hit Highlights</a>
-      <% end %>
-    <% end %>
-
-    <% if false %>
-    <div class="btn-group">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-        <span class="glyphicon glyphicon-download-alt"></span>
-        Download <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-        <li><a download="<%= @document.id %>.jpg" href="<%= hathitrust_image_src @document, size: ',1024' %>">Image</a></li>
-        <li><a href="<%= download_text_solr_document_path @document %>">Text</a></li>
-        <li><a href="<%= hathitrust_pdf_link @document %>">PDF</a></li>
-        <li class="divider"></li>
-        <li><a href="#">Issue (<%= @issue_data[:seq].size %>pg)...</a></li>
-      </ul>
-    </div>
-    <% end %>
-  </div>
-
-  <div class="btn-group-vertical action-group" role="group">
-    <a class="btn btn-default" download="<%= @document.id %>.jpg" href="<%= hathitrust_image_src @document, size: ',1024' %>">Download Image</a></li>
-    <a class="btn btn-default" href="<%= download_text_solr_document_path @document %>">Download Text</a></li>
-    <a class="btn btn-default" href="<%= hathitrust_pdf_link @document %>">Download PDF</a></li>
-    <a class="btn btn-default action-download-pdf" href="#">Download Issue PDF (<%= @issue_data[:seq].size %>pg)...</a>
-    <a class="btn btn-default" href="<%= download_issue_text_solr_document_path @document %>">Download Issue OCR (<%= @issue_data[:seq].size %>pg)...</a>
-  </div>
-
-
-</div>
-
-<div id="content" class="<%= show_content_classes %>" data-words="<%= process_highlighted_words(@document) %>" data-identifier="<%= @document.id %>" data-highlighting="<%= highlights_visible? ? 'true' : 'false' %>">
-  <div class="pagination-search-widgets">
-    <% if @subview == 'image' %>
+<div class="navbar" style="margin-bottom: 0">
+  <div class="container-fluid">
     <div class="pull-left">
-      <ul class="pager">
-        <li><span class="span-zoom-level bg-info">0</span></li>
-        <li><span class="span-zoom-status">100%</span></li>
-        <li><button class="btn btn-default action-zoom-in"><%= raw(t('views.issue.zoom_in')) %></button></li>
-        <li><button class="btn btn-default action-zoom-out"><%= raw(t('views.issue.zoom_out')) %></button></li>
-      </ul>
+      <ol class="breadcrumb" style="margin-bottom: 0">
+        <li><a href="<%= url_for('home') %>">The Michigan Daily</a></li>
+        <li><a href="#"><%= @document['date_issued_display'].first %> -  Issue <%= @document['issue_no_t'].first %></a></li>
+        <li class="active">Image <%= @document['sequence'] %></li>
+      </ol>
     </div>
-    <% end %>
-
-    <nav class="pull-right">
-      <ul class="pager">
-        <li>
-          <%= link_to_previous_issue_page @previous_page %>
-        </li>
-        <li><span><%= current_page_number(@document) %></span></li>
-        <li>
-          <%= link_to_next_issue_page @next_page %>
-        </li>
-      </ul>
-    </nav>
+    <div class="pull-right">
+        <ul class="pager" style="margin-bottom: 0">
+          <li>
+            <%= link_to_previous_issue_page @previous_page %>
+          </li>
+          <li><span><%= current_page_number(@document) %></span></li>
+          <li>
+            <%= link_to_next_issue_page @next_page %>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
-  <%= render_document_main_content_partial %>
 </div>
 
+<div id="image-viewer-wrap">
+  <div class="image-viewer-toolbar">
+    <div class="container">
+      <div class="col-md-3">
+        <% if highlights_available? %>
+          <span><input type="checkbox" class="action-toggle-highlight" <%= highlights_visible? ? 'checked="checked"' : '' %> /> Show Hit Highlights</span>
+        <% end %>        
+      </div>
+      <div class="col-md-6">
+        <div class="zoom-toolbar center-block" style="text-align: center">
+          <button class="btn btn-sm btn-default action-zoom-in"><%= raw(t('views.issue.zoom_in')) %></button>
+          <span class="span-zoom-status">100%</span>
+          <button class="btn btn-sm btn-default action-zoom-out"><%= raw(t('views.issue.zoom_out')) %></button>
+        </div>
+      </div>
+      <div class="col-md-3">
+      </div>
+    </div>
+  </div>
+  <div id="image-viewer" data-words="<%= process_highlighted_words(@document) %>" data-identifier="<%= @document.id %>" data-highlighting="<%= highlights_visible? ? 'true' : 'false' %>"></div>
+</div>
+
+<div class="container local-options-toolbar" style="display: flex; margin-bottom: 20px">
+    <div class="grid-col-md-4">
+      <h4><%= @document['date_issued_display'].first %> -  Issue <%= @document['issue_no_t'].first %></h4>
+    </div>
+    <div class="grid-col-md-4">
+      <div class="btn-group-vertical action-group" role="group">
+        <a class="btn btn-default" download="<%= @document.id %>.jpg" href="<%= hathitrust_image_src @document, size: ',1024' %>">Download Image</a></li>
+        <a class="btn btn-default" href="<%= download_text_solr_document_path @document %>">Download Text</a></li>
+        <a class="btn btn-default" href="<%= hathitrust_pdf_link @document %>">Download PDF</a></li>
+        <a class="btn btn-default action-download-pdf" href="#">Download Issue PDF (<%= @issue_data[:pages].size %>pg)...</a>
+        <a class="btn btn-default" href="<%= download_issue_text_solr_document_path @document %>">Download Issue OCR (<%= @issue_data[:pages].size %>pg)...</a>
+      </div>
+
+    </div>
+    <div class="grid-col-md-4">
+      <form>
+        <div class="form-group">
+          <label for="permalink">Permalink</label>
+          <input type="text" class="form-control" id="permalink" value="<%= solr_document_url(@document) %>" />
+        </div>
+        <button class="btn btn-default">Copy Link</button>
+      </form>
+    </div>
+</div>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-12" style="background: #fff">
+      <div class="row">
+        <div class="col-md-9 center-block" style="float: none; padding: 20px">
+      <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+        <div id="doc_<%= @document.id.to_s.parameterize %>">
+          <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+        </div>
+      </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<button id="configure-fit" class="btn btn-default" style="position: fixed; bottom: 10px; left: 5px;"><span class="glyphicon glyphicon-equalizer"></span></button>
+<script>
+  $().ready(function() {
+    $("#configure-fit").on('click', function(e) {
+      e.preventDefault();
+      var value = sessionStorage.getItem('best-fit-width') || 'false';
+      sessionStorage.setItem('best-fit-width', value == 'false');
+      window.location.reload();
+    })
+  });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,46 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Fishrappr</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => false %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => false %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
+<html lang="en" class="no-js">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
-<%= yield %>
+    <!-- Mobile viewport optimization h5bp.com/ad -->
+    <meta name="HandheldFriendly" content="True">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    
+    <!-- Internet Explorer use the highest version available -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<%= render partial: 'footer.html.erb' %>
+    <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
+    <!--[if IEMobile]>
+      <meta http-equiv="cleartype" content="on">
+    <![endif]-->
 
-</body>
+    <title><%= render_page_title %></title>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+
+    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+  </head>
+  <body class="<%= render_body_class %>">
+    <%= area :header do %>
+        <%= render :partial => 'shared/header_navbar' %>
+    <% end %>
+
+  <%= render partial: 'shared/ajax_modal' %>
+
+  <%= area :main do %>
+    <p>Main content goes here.</p>
+  <% end %>
+
+  <%= render :partial => 'shared/footer' %>
+  </body>
 </html>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,0 +1,18 @@
+<%= extends :application do %>
+
+  <%= replace :main do %>
+
+    <div class="<%= container_classes %>">
+      <%= content_tag :h1, application_name, class: 'sr-only application-heading' %>
+
+      <%= render :partial=>'/flash_msg', layout: 'shared/flash_messages' %>
+
+      <div class="row">
+        <%= yield %>
+      </div>
+
+    </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/layouts/pageview.html.erb
+++ b/app/views/layouts/pageview.html.erb
@@ -1,9 +1,5 @@
 <%= extends :application do %>
 
-    <% replace :header do %>
-        <%= render partial: 'home_header_navbar' %>
-    <% end %>
-
     <% replace :main do %>
         <%= yield %>
     <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,15 @@
+<footer class="navbar navbar-inverse">
+    <div class="container-fluid">
+        <ul class="nav navbar-nav">
+            <li class="footer-link-help"><%= link_to 'Help', static_path('about') %></li>
+            <li class="footer-link-home"><%= link_to 'Home', root_url %></li>
+        </ul>
+    </div>
+</footer>
+<div class="container-fluid">
+    <div class="col-md-12">
+        <p>
+            <span>&copy; 2016 Regents of the University of Michigan</span>
+        </p>
+    </div>
+</div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,0 +1,25 @@
+<div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <%= link_to application_name, root_path, class: "navbar-brand" %>
+    </div>
+
+    <div class="collapse navbar-collapse" id="user-util-collapse">
+      <%= render :partial=>'/user_util_links' %>
+    </div>
+  </div>
+</div>
+
+<%= area :search_navbar do %>
+  <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
+    <div class="container-fluid">
+        <%= render_search_bar  %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Lots of changes:

- application.html.erb is the core layout; other layouts extend it, replacing the slots as necessary
-- @gordonleacock - the home page uses the body class blacklight-catalog-home now
- added _globals.scss to collect common design values (background colors, font stacks, etc)
- migrated the footer to shared/footer, vs. all layouts pulling from catalog/footer
- coded footer more like a bootstrap nav; moved the copyright under the footer as in mockups

This also is the first pass at reworking the pageview page; nestive whacking forced its early release.
