### PR TITLE
add title to facet numbers for screen readers

### DIFF
--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module FacetsHelper
+  include Blacklight::FacetsHelperBehavior
+
+  ##
+  # 9-12-16 GML Per Colin C made sr-only text more specific
+  # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
+  # @params (see #render_facet_value)
+  def render_selected_facet_value(facet_field, item)
+    sr_only_str = String.new("remove facet limit ")
+    sr_only_str << facet_display_value(facet_field, item)
+    remove_href = search_action_path(search_state.remove_facet_params(facet_field, item))
+    content_tag(:span, class: "facet-label") do
+      content_tag(:span, facet_display_value(facet_field, item), class: "selected") +
+      # remove link
+      link_to(remove_href, class: "remove") do
+        content_tag(:span, '', class: "glyphicon glyphicon-remove") +
+        content_tag(:span, sr_only_str, class: 'sr-only')
+      end
+    end + render_facet_count(item.hits, :classes => ["selected"])
+  end
+
+  ##
+  # 9-12-16 GML Per Colin C added title facet count span 
+  # Renders a count value for facet limits. Can be over-ridden locally
+  # to change style. And can be called by plugins to get consistent display. 
+  #
+  # @param [Integer] number of facet results
+  # @param [Hash] options
+  # @option options [Array<String>]  an array of classes to add to count span.
+  # @return [String]
+  def render_facet_count(num, options = {})
+    classes = (options[:classes] || []) << "facet-count"
+    content_tag("span", t('blacklight.search.facets.count', :number => number_with_delimiter(num)), :title=> 'Number of records', :class => classes)
+  end
+
+end

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,0 +1,13 @@
+<div class="panel panel-default facet_limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
+  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+    <h3 class="panel-title facet-field-heading">
+      <%#= link_to facet_field_label(facet_field.key), "#", :"data-no-turbolink" => true %>
+      <button><%= facet_field_label(facet_field.key) %></button>
+    </h3>
+  </div>
+  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'in' %>">
+    <div class="panel-body">
+      <%= yield %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
1. Updated sr-only span in def render_selected_facet_value(facet_field, item) to clarify what is being removed.

2. Added title attr to def render_facet_count(num, options = {}) to explain what the number represents.


