### PR TITLE
unify index/browse handling for current_search_params

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -226,6 +226,17 @@ module ApplicationHelper
     end
   end
 
+  def back_to_results_label
+    search_params = current_search_session.try(:query_params) || {}
+    return if search_params.blank?
+    STDERR.puts "AHOY ACTION #{search_params[:action]} : #{search_params}"
+    if search_params[:action] == 'browse'
+      t('blacklight.back_to_browse_html')
+    else
+      t('blacklight.back_to_search_html')
+    end
+  end
+
   # SEARCH SELECT OPTIONS  
   # See blacklight_range_limit/app/helpers/range_limit_helper.rb, use date_issued_yyy_ti
   # Used by date search box
@@ -265,6 +276,7 @@ module ApplicationHelper
   end  
   
   # BROWSE OPTIONS  
+
   # Used by browse page
   def get_decade_browse_options
     decades = [1890, 1900, 1910, 1920, 1930, 1940, 1950, 1960, 1970, 1980, 1990, 2000, 2010]

--- a/app/helpers/zzzzzz_helper.rb
+++ b/app/helpers/zzzzzz_helper.rb
@@ -13,5 +13,12 @@ module ZzzzzzHelper
   #   end
   # end
 
+  def document_index_view_type query_params=params
+    if query_params["action"] == 'browse'
+      :grid
+    else
+      default_document_index_view_type
+    end
+  end
 
 end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,33 +1,28 @@
 <%= replace :search_navbar do %>
-  <% if current_search_session %>
-    <div class="navigation-toolbar">
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-md-3">
-            <% if ( session[:show_browse_return] ) %>
-              <%= link_to t('blacklight.back_to_browse_html'), session[:show_browse_return_link], :class => 'btn btn-search-primary' %>
-            <% else %>
-              <%= link_back_to_catalog class: 'btn btn-search-primary', label: t('blacklight.back_to_search_html') %>
-             <% end %>
-                       
-          </div>
-          <div class="col-md-6 align-center">
-            <ul class="pager" style="margin-bottom: 0">
-              <li>
-                <%= link_to_previous_issue_page @previous_page %>
-              </li>
-              <li><span class="current-page-number">Image <%= current_page_number(@document) %> of <%= @issue_data[:pages].size %></span></li>
-              <li>
-                <%= link_to_next_issue_page @next_page %>
-              </li>
-            </ul>            
-          </div>
-          <div class="col-md-3 align-right">
-          </div>
+  <div class="navigation-toolbar">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-3">
+          <% if current_search_session %>
+            <%= link_back_to_catalog class: 'btn btn-search-primary', label: back_to_results_label %>
+          <% end %>
+        </div>
+        <div class="col-md-6 align-center">
+          <ul class="pager" style="margin-bottom: 0">
+            <li>
+              <%= link_to_previous_issue_page @previous_page %>
+            </li>
+            <li><span class="current-page-number">Image <%= current_page_number(@document) %> of <%= @issue_data[:pages].size %></span></li>
+            <li>
+              <%= link_to_next_issue_page @next_page %>
+            </li>
+          </ul>            
+        </div>
+        <div class="col-md-3 align-right">
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>
 
 <div id="image-viewer-wrap">


### PR DESCRIPTION
- track `page` as part of the search session
- track search session for `browse`
- remove hacking of `params` to set different views for `index` vs. `browse`
- tweak `show.html.erb` so that the navbar always shows regardless of whether there's an active search session