### PR TITLE
move setup_publication to context concern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,12 @@
 class ApplicationController < ActionController::Base
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
+  include Fishrappr::Context
   layout 'blacklight'
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :setup_publication
+  
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,7 +9,6 @@ class CatalogController < ApplicationController
 
   helper Fishrappr::ControllerOverride
 
-  before_action :setup_publication
   layout :resolve_layout
 
 

--- a/app/controllers/concerns/fishrappr/catalog.rb
+++ b/app/controllers/concerns/fishrappr/catalog.rb
@@ -312,16 +312,6 @@ module Fishrappr::Catalog
 
   
   private
-    def setup_publication
-      if params[:publication]
-        session[:publication] = params[:publication] # || Rails.configuration.default_publication
-      else
-        session[:publication] ||= Rails.configuration.default_publication
-        params[:publication] = session[:publication]
-      end
-      @publication = Publication.where(slug: session[:publication]).first
-    end
-
     def get_view
       session[:view] = params[:view] if params[:view]
       session[:view] ||= 'image'

--- a/app/controllers/concerns/fishrappr/context.rb
+++ b/app/controllers/concerns/fishrappr/context.rb
@@ -1,0 +1,15 @@
+module Fishrappr::Context
+  extend ActiveSupport::Concern
+
+  def setup_publication
+    if params[:publication]
+      session[:publication] = params[:publication] # || Rails.configuration.default_publication
+    else
+      session[:publication] ||= Rails.configuration.default_publication
+      params[:publication] = session[:publication]
+    end
+    @publication = Publication.where(slug: session[:publication]).first
+  end
+
+
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,5 @@
 class StaticController < ApplicationController
-  
+
   def page
 
     @page = SolrDocument.new(


### PR DESCRIPTION
Fixes issue where help/contact pages would balk because there was no publication object.