### PR TITLE
set up routes to handle http://digital.bentley.umich.edu/midaily

### DIFF
--- a/app/assets/stylesheets/modules/viewer.scss
+++ b/app/assets/stylesheets/modules/viewer.scss
@@ -77,6 +77,7 @@
 
     &.center-block {
         text-align: center;
+        white-space: nowrap;
     }
 
     > span {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,14 @@
 require 'digest'
 module ApplicationHelper
 
+  def publication_root_url
+    if @publication
+      publication_home_url(@publication.slug)
+    else
+      root_url
+    end
+  end
+
   ##
   # Link to the previous document in the current search context
   def link_to_previous_issue_page(previous_document)

--- a/app/views/catalog/_home_header_navbar.html.erb
+++ b/app/views/catalog/_home_header_navbar.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to(image_tag("The-Michigan-Daily-Digital-Archive-Header-Graphic.png",  :alt => "The-Michigan-Daily-Digital-Archive-Header-Graphic", :height => 35, style: 'margin-top: -8px'), root_url, :class => "navbar-brand") %>
+      <%= link_to(image_tag("The-Michigan-Daily-Digital-Archive-Header-Graphic.png",  :alt => "The-Michigan-Daily-Digital-Archive-Header-Graphic", :height => 35, style: 'margin-top: -8px'), publication_root_url, :class => "navbar-brand") %>
       <%#= link_to application_name, root_path, class: "navbar-brand" %>
     </div>
 

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -8,7 +8,7 @@
     <dd>Text</dd>
     <dt>Publication:</dt>
     <dd><%= document.fetch('publication_label') %></dd>
-    <% if document.fetch('page_no_t').first %>
+    <% if document.fetch('page_no_t', []).first %>
     <dt>Page Number:</dt>
     <dd><%= document.fetch('page_no_t').first %></dd>
     <% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to(image_tag("The-Michigan-Daily-Digital-Archive-Header-Graphic.png",  :alt => "The-Michigan-Daily-Digital-Archive-Header-Graphic", :height => 35, style: 'margin-top: -8px'), root_url, :class => "navbar-brand") %>
+      <%= link_to(image_tag("The-Michigan-Daily-Digital-Archive-Header-Graphic.png",  :alt => "The-Michigan-Daily-Digital-Archive-Header-Graphic", :height => 35, style: 'margin-top: -8px'), publication_root_url, :class => "navbar-brand") %>
 
       <%#= link_to application_name, root_path, class: "navbar-brand" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,30 +1,16 @@
 Rails.application.routes.draw do
 
-  # concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
-  # get 'pub/:publication_link/:ht_barcode/:date_issued_link/:sequence' => 'catalog#show', as: :in_context
-
-  # mount Blacklight::Engine => '/'
-  # mount BlacklightAdvancedSearch::Engine => '/'
-
-  # root to: "catalog#index"
-  root to: "catalog#home"
   concern :searchable, Blacklight::Routes::Searchable.new
 
+  root to: redirect("/#{Settings.default_publication}")
 
-  resource :catalog, only: [:index], as: 'catalog', path: '/search', controller: 'catalog' do
+  resource :search, only: [:index], controller: 'catalog', as: 'catalog' do
     concerns :searchable
-    ## concerns :range_searchable
-
   end
 
-  # devise_for :users
-  # concern :exportable, Blacklight::Routes::Exportable.new
+  get '/browse' => 'catalog#browse', as: :browse
 
-  # resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
-  #   concerns :exportable
-  # end
-
-  resources :solr_documents, only: [:show], path: '/view', controller: 'catalog',
+  resources :solr_documents, only: [:show], path: '/pages', controller: 'catalog',
     constraints: { id: /[^\/]+/ }  do
     member do
       post 'toggle_highlight'
@@ -32,25 +18,12 @@ Rails.application.routes.draw do
       get 'download_issue_text'
       get 'issue_data'
     end
-
   end
-
-  # resources :bookmarks do
-  #   concerns :exportable
-
-  #   collection do
-  #     delete 'clear'
-  #   end
-  # end
 
   match '/contacts', to: 'contacts#new', via: 'get'
   resources "contacts", only: [:new, :create]
 
   post 'static/search' => 'static#search'
-  
-  get '/home' => 'catalog#home'
-
-  get '/browse' => 'catalog#browse', as: :browse
 
   get 'static/:action' => 'static', as: :static
 
@@ -58,5 +31,6 @@ Rails.application.routes.draw do
   get 'services/annotations/:id' => 'services_api#annotations', as: :services_annotations, format: false, defaults: { format: :json }
   get 'services/coords/:id' => 'services_api#coords', as: :services_coords, format: false, defaults: { format: :json }
 
+  get '/:publication', to: 'catalog#home', as: 'publication_home'
 
 end


### PR DESCRIPTION
- redirects the root request to the default publication (currently: `the-michigan-daily`; planned: `midaily`)
- updates the header to use `publication_root_url`
- (minor template and CSS fixes)