### PR TITLE
update index page style to match zeplin

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -90,7 +90,7 @@ span.subtitle {
     font-size: 90%;
 }
 
-// SCSS for index page only
+// SCSS for index page only **************
 .blacklight-catalog-index {
 
     // #documents-list article {
@@ -102,23 +102,31 @@ span.subtitle {
 
     #documents h3 {
         display: inline-block;
+        font-family: 'Open Sans';
+        font-size: 27px;
+        color: #333333;
     }
 
     #documents .row-thumbnail {
         display: inline-block;
-        width: 200px;
+        width: 160px;
         margin-top: 0;
+        margin-left: 10px;
         vertical-align: top;
     }
 
     // Use calc to resize row article text
     #documents .row-article-text {
         display: inline-block;
-        width: calc(100% - 250px);
+        width: calc(100% - 230px);
         padding-left: 20px;
-        
+        font-family: Helvetica;
+        font-size: 16px;
+        line-height: 1.5;
+        color: #333333;
+
         h3 {
-         display: inline-block;
+            display: inline-block;
         }
     }
 
@@ -149,6 +157,8 @@ span.subtitle {
         display: inline-block;
         width: auto;
         height: auto;
+        background-color: #ffffff; // override bootstrap
+        border: 0 solid white;     // override bootstrap
     }
 
     // .thumbnail {
@@ -193,10 +203,12 @@ span.subtitle {
     }
 
     span.subtitle {
-        font-size: 75%;
-        margin-top: 4px;
+        color: #6e6e6e;
         display: block;
-        color: #5c9bd2
+        font-family: 'Open Sans';
+        font-size: 16px;
+        line-height: 1.2;
+        margin-top: 3px;
     }
 
     .caption span.subtitle {

--- a/app/assets/stylesheets/bootstrap-variables.scss
+++ b/app/assets/stylesheets/bootstrap-variables.scss
@@ -23,3 +23,5 @@ $font-family-sans-serif: $base-fonts;
 
 $padding-base-vertical: 9px;
 $padding-base-horizontal: 16px;
+
+$sys-font-family: hevetica;

--- a/app/assets/stylesheets/modules/custom.scss
+++ b/app/assets/stylesheets/modules/custom.scss
@@ -11,25 +11,25 @@
   div.search-widgets {
     display: inline-block;
     float: right;
-    // margin-left: auto;
-    // margin-right: auto;
-    // margin-top: 20px;
-    width: auto;
-
+    font-family: $sys-font-family;
+    font-size: 16px;
+    height: 44px;
     line-height: 2.1;
-    font-size: 14px;
     padding: 0px 12px;
     padding-top: 8px;
-    height: 44px;
+    width: auto;
+    margin-bottom: 10px;
 
     #sort-dropdown {
-      margin-right: 10px;
+      margin-right: 0;
 
       button {
         line-height: 1.42857143;
         vertical-align: middle;
         padding: 10px 12px;
-        font-size: 14px;
+        font-family: $sys-font-family;
+        font-size: 16px;
+        color: #4e4e4e;
      }
     }
   }
@@ -43,17 +43,16 @@
     width: auto;
 
     span.page_entries {
-        -khtml-border-radius: 4px;
-        -moz-border-radius: 4px;
-        -webkit-border-radius: 4px;
-        background-color: #f5f5f5;
+        -khtml-border-radius: 3px;
+        -moz-border-radius: 3px;
+        -webkit-border-radius: 3px;
+        // border-color: #ccc;        
+        // border: solid 1px #ccc;
+        // color: #337ab7;
         background-color: #fff;
-        border-color: #ccc;        
-        border-radius: 4px; 
-        border: solid 1px #ccc;
-        color: #337ab7;
+        border-radius: 3px; 
         display: inline-block;
-        font-size: 14px;
+        font-size: 16px;
         line-height: 2.1;
         margin-right: 10px;
         padding: 0 10px;
@@ -65,22 +64,14 @@
     }
 
      span.prev-next {
-       -khtml-border-radius: 4px;
-       -moz-border-radius: 4px;
-       -webkit-border-radius: 4px;
-       background-color: #fff;
-       border-color: #ccc;
-       border-radius: 4px; 
-       border: 1px solid #ccc;
-       color: #337ab7;
-       display: inline-block;
-       padding: 6px 12px;
-       font-size: 14px;
-       line-height: 2.1;
-       vertical-align: middle;
-       min-width: 140px;
-
-       text-align: center;
+      color: #333333;
+      display: inline-block;
+      font-family: $sys-font-family;
+      font-size: 16px;
+      line-height: 2.1;
+      min-width: 140px;
+      text-align: center;
+      vertical-align: middle;
 
      }
 
@@ -91,16 +82,24 @@
     }
 
     span.pages-box {
-      border-right: 1px solid #ccc;
-      margin-right: 0; // 8px;
+      border-right: 2px solid rgb(242,242,242) !important;
+      margin-right: 0;
       padding-right: 16px;
       padding-top: 6px; 
       padding-bottom: 6px;
+      color: #333333;
       display: inline-block;
+      font-family: $sys-font-family;
+      font-size: 16px;
+      line-height: 2.1;
     }
 
     span.results-box {
+      color: #333333;
       display: inline-block;
+      font-family: $sys-font-family;
+      font-size: 16px;
+      line-height: 2.1;
       padding-top: 6px; 
       padding-bottom: 6px;
       margin-left: 8px;
@@ -240,34 +239,44 @@ body.blacklight-catalog-index #search-navbar , body.blacklight-catalog-home {
 
     .form-control, .q-block {
       display: block;
-      margin-top:  .5em;
+      margin-top:  5px;
+      margin-bottom: 10px;
       text-align: left;
     }
 
+    #q {
+      margin-right: 5px;
+    }
+
     .form-control, .date-option, .input-layout-group {
-      width: 12em;
+      width: 120px;
     }
 
     #date_filter, #q, .search-label {
       display: inline-block;
     }
 
+    #date_filter {
+      width: 200px;
+    }
+
     .search-label {
-      width: 4em;
+      width: 60px;
       text-align: left !important;
     }
 
     .for-label {
-      width: 2em;
+      width: 40px;
     }
 
     input[name="yy[1]"] {
-      width: 5em !important;
+      width: 50px !important;
     }
 
     .date-option {
       display: none;
     }
+
 
     @media (min-width: 768px) {
       .date-input-control {
@@ -281,18 +290,18 @@ body.blacklight-catalog-index #search-navbar , body.blacklight-catalog-home {
       
       .form-control, .q-block {
       display: inline-block;
-      margin-top:  .5em;
+      margin-top:  5px;
       text-align: left;
      }
       
       .for-label {
         text-align:  center !important;
-        width: 3em;
+        width: 30px;
       }
     }
 
     #q {
-      min-width: 20em;
+      min-width: 300px;
     }
   }
 }
@@ -323,14 +332,73 @@ body.blacklight-catalog-home {
   }
 }
 
+/* STYLES FOR CATALOG PAGE */
 
-// facet styling
+// index and facet styling
 body.blacklight-catalog-index {
+
+  #getting-started {
+
+    .description {
+      font-size: 16px;
+      text-align: center;
+      color: #6e6e6e;
+      margin-top: 16px
+    }
+
+    .page-heading, .section-heading, p {
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
+
+    .divider {
+      width: 360px;
+      height: 2px;
+      background-color: #e5e5e5;
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
+  }
 
   h2.facets-heading {
     display: none;
     height: 0;
     width: 0;
+  }
+
+  .pagination > li {
+
+    a {
+      color: white;
+      border-radius: 3px;
+      background-color: #126dc1;
+      border: solid 2px #0c5292;
+      margin-left: 3px;
+      margin-right: 3px;    
+    }
+
+
+
+    .gap-truncate {
+      background-color: rgb(242,242,242);
+      border: 0;
+    }
+
+    &.active span, .next, .prev {
+      color: #126dc1;
+      border-radius: 3px;
+      border: solid 2px #126dc1;
+      background-color: rgb(242,242,242);
+      width: 56px;
+    }
+
+    &.active span {
+      margin-left: 3px;
+      margin-right: 3px; 
+      width: auto;
+    }
   }
 
   #sidebar {
@@ -340,7 +408,7 @@ body.blacklight-catalog-index {
 
       .constraints-label {
         display: block;
-        font-family: Helvetica;
+        font-family: $sys-font-family;
         font-size: 14px;
         color: #333333;
         margin: 0 0 5px 0;
@@ -349,15 +417,19 @@ body.blacklight-catalog-index {
       .constraint-value {
         background-color: #05a657 !important;
         color: #ffffff;      
-        font-family: Helvetica;
+        font-family: $sys-font-family;
         font-size: 16px;
         padding: 6px 10px;
         width: 141px;
+
+        .filterName:after {
+          color: white;
+        }
       }
 
       a.dropdown-toggle {
         background-color: rgba(26,165,90, .36);
-        font-family: Helvetica;
+        font-family: $sys-font-family;
         font-size: 16px;
         padding: 6px 10px;
       }
@@ -367,7 +439,7 @@ body.blacklight-catalog-index {
         border-radius: 3px;
         box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.36);
         color: #ffffff;
-        font-family: Helvetica;
+        font-family: $sys-font-family;
         font-size: 14px;
         font-weight: normal !important;
         margin-top: 5px;
@@ -393,7 +465,7 @@ body.blacklight-catalog-index {
 
       h5 {
         color: #555555;
-        font-family: Helvetica;
+        font-family: $sys-font-family;
         font-size: 16px;
       }
 
@@ -404,11 +476,89 @@ body.blacklight-catalog-index {
 
     .facets-heading {
       color: #555555;
-      font-family: Helvetica;
+      font-family: $sys-font-family;
       font-size: 16px;
     }
   }
 }
+
+
+// Catalog page search at top of page
+
+div.top-panel-heading {
+  margin-left: -15px;
+}
+
+.catalog_startOverLink {
+  background-color: white;
+  font-family: inherit;
+  font-weight: bold !important;
+  line-height: 1.1;
+  font-size: 14px !important;
+  border: 1px solid #337ab7;
+}
+
+.back-to-top {
+  cursor: pointer;
+  position: fixed;
+  bottom: 5px;
+  right: 20px;
+  display:none;
+  border: 3px solid #337ab7;
+  z-index: 100;
+  color: $gray-lighter;
+}
+
+.back-to-top-text {
+  display: block;
+  font-size: .7em;
+  font-weight: bold;
+}
+
+body.blacklight-catalog-index {
+  article.document {
+      @include make-row;
+
+      span.document-metadata {
+        font-weight: bold;
+
+        span.blacklight-page_text {
+          display: block;
+          font-weight: normal;
+        }
+      }  
+
+      div.document-thumbnail {
+        float: left !important;
+        height: 150px;
+        margin-left: 0 !important;
+        margin-right: 20px;
+        padding: 0;
+        width: 150px;
+      }
+    }
+
+  // div.fishrappr_panel {
+  //   background-color: #fff;
+  //   border-radius: 4px; 
+  //   border: 1px solid #ccc;
+  //   color: #337ab7;
+  //   display: inline-block;
+  //   font-size: 16px;
+  //   margin-bottom: 1em;
+  //   padding: 10px;
+  //   vertical-align: middle;
+  // }
+
+  div#sortAndPerPage {
+    @include pagination-toolbar;
+    padding-left: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+}
+
 //   form.range_date_issued_yyyymmdd_ti {
 
 //     input#range_date_issued_yyyymmdd_ti_begin,
@@ -598,83 +748,7 @@ body.blacklight-catalog-browse {
 }
 
 
-/* STYLES FOR CATALOG PAGE */
 
-// Catalog page search at top of page
-
-div.top-panel-heading {
-  margin-left: -15px;
-}
-
-.catalog_startOverLink {
-  background-color: white;
-  font-family: inherit;
-  font-weight: bold !important;
-  line-height: 1.1;
-  font-size: 14px !important;
-  border: 1px solid #337ab7;
-}
-
-.back-to-top {
-  cursor: pointer;
-  position: fixed;
-  bottom: 5px;
-  right: 20px;
-  display:none;
-  border: 3px solid #337ab7;
-  z-index: 100;
-  color: $gray-lighter;
-}
-
-.back-to-top-text {
-  display: block;
-  font-size: .7em;
-  font-weight: bold;
-}
-
-body.blacklight-catalog-index {
-  article.document {
-      @include make-row;
-
-      span.document-metadata {
-        font-weight: bold;
-
-        span.blacklight-page_text {
-          display: block;
-          font-weight: normal;
-        }
-      }  
-
-      div.document-thumbnail {
-        float: left !important;
-        height: 150px;
-        margin-left: 0 !important;
-        margin-right: 20px;
-        padding: 0;
-        width: 150px;
-      }
-    }
-
-  // div.fishrappr_panel {
-  //   background-color: #fff;
-  //   border-radius: 4px; 
-  //   border: 1px solid #ccc;
-  //   color: #337ab7;
-  //   display: inline-block;
-  //   font-size: 16px;
-  //   margin-bottom: 1em;
-  //   padding: 10px;
-  //   vertical-align: middle;
-  // }
-
-  div#sortAndPerPage {
-    @include pagination-toolbar;
-    padding-left: 0;
-    margin-bottom: 0;
-    padding-bottom: 0;
-  }
-
-}
 
 /* STYLES FOR HOME PAGE */
 
@@ -799,7 +873,7 @@ body.blacklight-catalog-home {
   a {
     border: solid 2px #ffffff;
     color: #ffffff;
-    font-family: Helvetica;
+    font-family: $sys-font-family;
     font-size: 16px;
     margin-left:auto;
     margin-right:auto;
@@ -837,7 +911,7 @@ body.blacklight-catalog-home {
   a {
     border: solid 2px #ffffff;
     color: #ffffff;
-    font-family: Helvetica;
+    font-family: $sys-font-family;
     font-size: 16px;
     margin-left:auto;
     margin-right:auto;
@@ -967,7 +1041,7 @@ body.blacklight-catalog-home {
     border-radius: 3px;
     border: 2px solid #126dc1;
     color: #126dc1;
-    font-family: Helvetica;
+    font-family: $sys-font-family;
     font-size: 16px;
     margin-top: 25px;
     min-width: 12em;

--- a/app/assets/stylesheets/modules/grid.scss
+++ b/app/assets/stylesheets/modules/grid.scss
@@ -20,9 +20,9 @@
     a.thumbnail {
         margin-bottom: 10px;
 
-        padding: 2px;
-        box-shadow: 0 0 2px rgba(0, 0, 0, .34);
-        border: 1px solid white;
+        // padding: 2px;
+        // box-shadow: 0 0 2px rgba(0, 0, 0, .34);
+        // border: 1px solid white;
         z-index: 0;
 
         &:before,

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -14,7 +14,7 @@ module FacetsHelper
       content_tag(:span, facet_display_value(facet_field, item), class: "selected") +
       # remove link
       link_to(remove_href, class: "remove") do
-        content_tag(:span, '', class: "glyphicon glyphicon-remove") +
+        content_tag(:span, '', class: "fa fa-close") +
         content_tag(:span, sr_only_str, class: 'sr-only')
       end
     end + render_facet_count(item.hits, :classes => ["selected"])

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -1,0 +1,33 @@
+<%  # local params:
+    # label
+    # value
+    # options =>
+    #   :remove => url for a remove constraint link
+    #   :classes => array of classes to add to container span
+    options ||= {}
+%>
+
+<span class="btn-group appliedFilter constraint <%= options[:classes].join(" ") if options[:classes] %>">
+  <span class="constraint-value btn btn-sm btn-default btn-disabled">
+    <% unless label.blank? %>
+      <span class="filterName"><%= label %></span>
+    <% end %>
+    <% unless value.blank? %>
+      <%= content_tag :span, value, class: 'filterValue', title: value %>
+    <% end %>
+  </span>
+  <% unless options[:remove].blank? %>
+    <% accessible_remove_label = content_tag :span, class: 'sr-only' do
+        if label.blank?
+          t('blacklight.search.filters.remove.value', value: value)
+        else
+          t('blacklight.search.filters.remove.label_value', label: label, value: value)
+        end
+      end
+    %>
+
+    <%= link_to(content_tag(:span, '', class: 'fa fa-close') + accessible_remove_label,
+      options[:remove], class: 'btn btn-default btn-sm remove dropdown-toggle'
+    ) %>
+  <%- end -%>
+</span>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,7 +1,7 @@
 <% # container for a single doc -%>
 <article class="row document" data-words="<%= process_highlighted_words(document) %>" data-identifier="<%= iiif_identifier(document, 'coordinates_link') %>">
     <span class="row-thumbnail" aria-hidden="true" tabindex="-1">
-        <%= link_to document_thumbnail(document, size: ',250'), url_for_document(document), { tabindex: '-1', class: 'thumbnail loading' , **(document_thumbnail_data(document, size: ',250')) } %>
+        <%= link_to document_thumbnail(document, size: '150,'), url_for_document(document), { tabindex: '-1', class: 'thumbnail loading' , **(document_thumbnail_data(document, size: '150,')) } %>
     </span>
     <span class="row-article-text">
         <%= render partial: '/catalog/index_default.html', locals: { document: document } %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,9 +1,16 @@
 <div class="page-header row">
-  <h2 class="col-md-8 page-heading"><%= t('blacklight.welcome') %></h2>
+  <div class="col-md-8"></div>
 </div>
 
 <div id="getting-started">
-  <h3 class='section-heading'>Michigan Daily Archives</h3>
+  <h2 class='page-heading'><i class="fa fa-search fa-10x"></i></h2>
+  <div class="divider"></div>
+  <h3 class='section-heading'>Try a new search</h3>
+  <div class="divider"></div>
+  <p class="description">Some Examples to get started:</p>
+  <p><“Apple AND Computers”/p>
+  <p>“Wolverine NOT Football”</p>
+  <p>“DIAG + Squirrels”</p>
   
 </div>
 <script>

--- a/app/views/kaminari/blacklight/_first_page.html.erb
+++ b/app/views/kaminari/blacklight/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.first? %>">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+</li>

--- a/app/views/kaminari/blacklight/_gap.html.erb
+++ b/app/views/kaminari/blacklight/_gap.html.erb
@@ -1,0 +1,11 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="disabled">
+  <span class="gap-truncate"><%= raw(t 'views.pagination.truncate') %></span>
+</li>
+

--- a/app/views/kaminari/blacklight/_last_page.html.erb
+++ b/app/views/kaminari/blacklight/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'disabled' if current_page.last? %>">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+</li>

--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -1,0 +1,17 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if current_page.last? %>
+    <li class="disabled">
+      <%= link_to raw(t 'views.pagination.next'), '#', :class => 'next', :rel => 'next', :onclick=>'return false;' %>
+    </li>
+<% else %>
+    <li>
+      <%= link_to raw(t 'views.pagination.next'), url, :class => 'next', :rel => 'next', :remote => remote %>
+    </li>
+<% end %>

--- a/app/views/kaminari/blacklight/_page.html.erb
+++ b/app/views/kaminari/blacklight/_page.html.erb
@@ -1,0 +1,17 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="<%= 'active' if page.current? %>">
+  <% if page.current? %>
+    <span><%= number_with_delimiter(page.to_s) %></span>
+  <% else %>
+    <%= link_to number_with_delimiter(page.to_s), url, opts = {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <% end %>
+</li>
+

--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+-%>
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= prev_page_tag %>
+    <% each_relevant_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>  
+    <%= next_page_tag  %>
+  </ul>
+<% end -%>

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -1,0 +1,18 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if current_page.first? %>
+    <li class="disabled">
+      <%= link_to raw(t 'views.pagination.previous'), '#', :class => 'prev', :rel => 'prev', :onclick=>'return false;' %>
+    </li>
+<% else %>
+    <li>
+      <%= link_to raw(t 'views.pagination.previous'), url, :class => 'prev', :rel => 'prev', :remote => remote %>
+    </li>
+<% end %>
+

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -36,10 +36,10 @@ en:
       pagination:
         first: '&laquo; First'
         last: 'Last &raquo;'
-        previous: '&laquo; Previous'
-        next: 'Next &raquo;'
+        previous: '<span class="sr-only">Previous page arrow button</span><span class="fa fa-arrow-left">'
+        next: '<span class="sr-only">Next page arrow button</span><span class="fa fa-arrow-right">'
         truncate: '…'
 
       pagination_compact:
-        previous: '<span class="prev-next"><span class="glyphicon glyphicon-arrow-left"></span><span class="hidden-xs"> Previous<span class="hidden-sm"> page</span></span></span>'
-        next: '<span class="prev-next"><span class="hidden-xs">Next<span class="hidden-sm"> page</span> </span><span class="glyphicon glyphicon-arrow-right"></span></span>'
+        previous: '<span class="prev-next"><span class="fa fa-arrow-left"></span><span class="hidden-xs"><span class="sr-only">Previous page arrow button</span> Previous<span class="hidden-sm"> page</span></span></span>'
+        next: '<span class="prev-next"><span class="hidden-xs"><span class="sr-only">Next page arrow button</span>Next<span class="hidden-sm"> page</span> </span><span class="fa fa-arrow-right"></span></span>'


### PR DESCRIPTION
**update index page style to match zeplin but**

1. No fix for empty results page content or graph yet.
2. No fix for responsiveness yet.
3. I'm not happy with the look of the li.active in the bottom pagination yet.
4. We could switch over to all "open sans" font but this still has Helvetica in places.
5. No icon changes yet.
