### PR TITLE
contact form updates

### DIFF
--- a/app/assets/stylesheets/fishrappr.scss
+++ b/app/assets/stylesheets/fishrappr.scss
@@ -4,3 +4,4 @@
 @import 'modules/grid';
 @import 'modules/modals';
 @import 'modules/viewer';
+@import 'modules/contacts';

--- a/app/assets/stylesheets/modules/contacts.scss
+++ b/app/assets/stylesheets/modules/contacts.scss
@@ -1,0 +1,121 @@
+.blacklight-contacts {
+  .inner-form {
+    margin: 0 -15px;
+    padding: 0;
+  }
+
+  .form-group {
+    position: relative;
+    margin-bottom: 25px;
+
+    .form-control {
+      border: 2px solid #ccc;
+    }
+
+    &.required {
+      margin-bottom: 50px;
+    }
+
+    .required.required-tag {
+      position: absolute;
+      bottom: -25px;
+      left: 0;
+      color: #057c42;
+      font-size: 13px;
+      text-transform: capitalize;
+    }
+
+  }
+
+  .form-group.required + .form-group.optional {
+    margin-top: -25px;
+  }
+
+  #new_contact label, .contact {
+    display: block;
+    margin-right: 0px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    text-align: left;
+    width: 20em;
+    font-size: 120%;
+  }
+
+  // #new_contact  .checkbox label {
+  //   margin-top: 12px;
+  // }
+
+  #new_contact  span.spacer {
+    display: block;
+    height: 40px;
+  }
+
+  // #new_contact  textarea {
+  //   height: 100px;
+  //   width: 500px;
+  // }
+
+  #new_contact span.error {
+    bolder: solid 2px red;
+    display: inline-block;
+    margin-left: 20px;
+    padding: 4px;
+  }
+
+  #new_contact div.field_with_errors span.error {
+    font-style: bold italic;
+    font-size: 1.2em;
+  }
+
+  #new_contact .btn {
+    color: white;
+    margin-left: -15px;
+    margin-bottom: 50px;
+    // /margin-top: -25px;
+  }
+
+  p.help-block {
+    font-style: italic;
+    margin-bottom: 0;
+  }
+
+  #new_contact abbr {
+    display: none;
+  }
+
+  .prompt {
+    display: none;
+  }
+
+  .prompt.visible {
+    display: block;
+  }
+
+
+  // #new_contact .required-tag {
+  //   background-color: #10788E;
+  //   border-radius: 0.2rem;
+  //   bottom: 0.2rem;
+  //   color: #FFF;
+  //   display: inline-block;
+  //   font-size: 0.7rem; // falafel
+  //   font-size: 90%;
+  //   font-weight: normal;
+  //   line-height: 1em;
+  //   padding: 0.2rem 0.4rem;
+  //   position: relative;
+  //   text-shadow: none;
+  //   vertical-align: super;
+  // }
+
+}
+
+@media (min-width: 992px) {
+  .blacklight-contacts .inner-form .col-md-6 {
+      width: 48%;
+
+      &:last-child {
+        margin-left: 2%;
+      }
+  }
+}

--- a/app/assets/stylesheets/modules/custom.scss
+++ b/app/assets/stylesheets/modules/custom.scss
@@ -1,5 +1,3 @@
-/* CONTACT FORM */
-// @import "globals";
 
 @mixin pagination-toolbar {
   background-color: transparent; // #f5f5f5;
@@ -111,73 +109,11 @@
 
 .hidden { display: none; }
 
-#new_contact label, .contact {
-  display: block;
-  margin-right: 0px;
-  margin-top: 10px;
-  text-align: left;
-  width: 20em;
-}
-
-#new_contact  .checkbox label {
-  margin-top: 12px;
-}
-
-#new_contact  span.spacer {
-  display: block;
-  height: 40px;
-}
-
-#new_contact  textarea {
-  height: 100px;
-  width: 500px;
-}
-
-#new_contact span.error {
-  bolder: solid 2px red;
-  display: inline-block;
-  margin-left: 20px;
-  padding: 4px;
-}
-
-#new_contact div.field_with_errors span.error {
-  font-style: bold italic;
-  font-size: 1.2em;
-}
-
-#new_contact .btn {
-  color: white;
-  margin-left: -15px;
-  margin-bottom: 50px;
-}
-
-p.help-block {
-  font-style: italic;
-  margin-bottom: 0;
-}
-
-#new_contact abbr {
-  display: none;
-}
-
-
-#new_contact .required-tag {
-  background-color: #10788E;
-  border-radius: 0.2rem;
-  bottom: 0.2rem;
-  color: #FFF;
-  display: inline-block;
-  font-size: 0.7rem; // falafel
-  font-size: 90%;
-  font-weight: normal;
-  line-height: 1em;
-  padding: 0.2rem 0.4rem;
-  position: relative;
-  text-shadow: none;
-  vertical-align: super;
-}
-
 /*flash*/
+
+#main-flashes {
+  margin-top: 20px;
+}
 
 .alert-error {
   background-color: #f2dede;

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,6 +1,8 @@
 class ContactsController < ApplicationController  
   def new
     @contact = Contact.new
+    @contact.referer = request.referer if request.referer && request.referer.start_with?(request.base_url)
+    @contact.type = t('views.contacts.types')[params[:type].to_sym] if params[:type]
   end
 
   def create
@@ -9,16 +11,16 @@ class ContactsController < ApplicationController
     # could use the following to set headers if needed?
     # if @contact.request["contact"]["type"] == "Permissions request or question"
 
-  # not spam and a valid form
+    # not spam and a valid form
     if @contact.respond_to?(:deliver_now) ? @contact.deliver_now : @contact.deliver
-      flash.now[:notice] = 'Thank you for your message!'
+      # flash.now[:notice] = 'Thank you for your message!'
       after_deliver
-      @contact = Contact.new
+      render :success
     else
       flash.now[:error] = 'Sorry, this message was not sent successfully. '
       flash.now[:error] << @contact.errors.full_messages.map(&:to_s).join(",")
+      render :new
     end
-    render :new
   rescue
     flash.now[:error] = 'Sorry, this message was not delivered.'
     render :new

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,6 +7,7 @@ class Contact < MailForm::Base
   attribute :email, validate: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
   attribute :type
   attribute :message, validate: true
+  attribute :referer, validate: false
   # - can't use this without ActiveRecord::Base validates_inclusion_of :issue_type, in: ISSUE_TYPES
 
   # Declare the e-mail headers. It accepts anything the mail method

--- a/app/views/catalog/_image_viewer_toolbar_bottom.html.erb
+++ b/app/views/catalog/_image_viewer_toolbar_bottom.html.erb
@@ -20,7 +20,7 @@
         <% if highlights_available? %>
           <label><input type="checkbox" class="action-toggle-highlight" <%= highlights_visible? ? 'checked="checked"' : '' %> /> <%= raw t('views.issue.search_highlights') %></label>
         <% end %>
-        <a href="#" class="btn btn-primary" style="color: #fff"><i class="fa fa-exclamation-triangle"></i> Report Problem</a>
+        <a href="<%= contacts_path type: 'image' %>" class="btn btn-primary action-report-problem" style="color: #fff"><i class="fa fa-exclamation-triangle"></i> Report Problem</a>
       </div>
 
     </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -106,7 +106,7 @@ $().ready(function() {
     e.preventDefault();
     $("#permalink").select();
     document.execCommand('copy');
-  })
+  });
 });
 </script>
 <%= render partial: 'back_to_top' %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -4,18 +4,70 @@
     <%= render partial: 'static/unified_sidebar' %>
 
   <div class="<%= main_content_classes %> help-middle-col">
-     <h2 classs="title"><%= t('views.static.contact.title') %></h2>
+    <h2 classs="title"><%= t('views.static.contact.title') %></h2>
     <p class="para">We are happy to answer any questions you have about using the Michigan Daily archive, to hear about any problem you are experiencing with the system and to hear your feeback on how we can improve our services.</p>
     <div class="<%= main_content_classes %>">
 
-    <%= simple_form_for @contact, :html => {:class => 'form-horizontal' } do |f| %>
-      <%= f.input :username, label: "Name", placeholder: 'Your name please', :required => true %>
-      <%= f.input :email, label: "Email Address", placeholder: 'For example: user@yahoo.com OR uniqname@umich.edu', :required => true,  :class => "simple_label" %>
-      <%= f.input :type, label: "Problem Type", as: :select, collection: ["Searching", "Problem with content or metadata", "Technical support", "Permissions request or question", "Image orientation wrong in page viewer",  "General comment or concern", "Other"], prompt: "Please select the type of problem" %>
-      <%= f.input :message, placeholder: 'Please describe your problem', as: :text, :required => true, :class => "simple_label", :rows => "10", :cols => "50" %>
-      <span class="spacer"></span>
-      <%= f.button :submit, 'Send Message', :class=> "btn btn-primary" %>
-    <% end %>
-      </div>
-    </div> 
+      <%= simple_form_for @contact, :html => {:class => 'form-horizontal' } do |f| %>
+        <div class="container-fluid inner-form">
+          <div class="col-md-6 col-xs-12 padded">
+            <%= f.input :username, label: "Your Name", placeholder: 'Your name please', :required => true %>
+          </div>
+          <div class="col-md-6 col-xs-12">
+            <%= f.input :email, label: "Email", placeholder: 'you@example.com', :required => true %>
+          </div>
+        </div>
+        <%= f.input :type, label: "What do you need help with?", as: :select, collection: t('views.contacts.types').values, prompt: "Please select the type of problem" %>
+        <%= f.input :message, label: 'Write a Message', placeholder: 'Please describe your problem', as: :text, :required => true, input_html: { rows: 5 } %>
+
+        <div class="alert alert-warning alert-block">
+          <% prompts = t('views.contacts.prompts') %>
+          <% prompts.each do |key, value| %>
+              <p class="prompt prompt-<%= key %>"><%= value %></p>
+          <% end %>
+          <p>
+            We reorded your last page to help troubleshoot the issue. We'll let you focus on describing your issue.
+          </p>
+        </div>
+
+        <%= f.input :referer, as: :hidden %>
+        <span class="spacer"></span>
+        <div class="container-fluid inner-form">
+          <div class="col-md-4">
+            <%= f.button :submit, 'Send Message', :class=> "btn btn-primary" %>
+          </div>
+          <% if @contact.referer %>
+          <div class="col-md-8 align-right">
+            <p><i class="fa fa-exclamation"></i> <em>The last page you viewed has been recorded.</em></p>
+          </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div> 
 </div>
+
+<script type="text/javascript">
+  var type_map = {};
+  <% t('views.contacts.types').each do |key, value| %>
+  type_map["<%= value %>"] = "<%= key %>";
+  <% end %>
+
+  var show_prompt = function(value) {
+    var key = type_map[value];
+    $(".prompt.visible").removeClass("visible");
+    $(".prompt-" + key).addClass("visible");
+  }
+  
+  $().ready(function() {
+    // the sins we start with
+    var $type = $("#contact_type");
+    show_prompt($type.val());
+
+    $type.on('change', function() {
+      console.log("AHOY", $type.val());
+      show_prompt($type.val());
+    })
+
+  })
+</script>

--- a/app/views/contacts/success.html.erb
+++ b/app/views/contacts/success.html.erb
@@ -1,0 +1,22 @@
+<% @page_title = t('views.static.contact.title') %>
+
+<div class="container-fluid">
+  <%= render partial: 'static/unified_sidebar' %>
+
+  <div class="<%= main_content_classes %> help-middle-col">
+    <h2 classs="title"><%= t('views.static.contact.title') %></h2>
+
+    <div class="alert alert-block alert-success"><p>Thank you for your message!</p></div>
+
+    <p class="para">We appreciate your help in making our services better for everyone.</p>
+
+    <% unless @contact.referer.blank? %>
+    <p>
+      <a href="<%= @contact.referer %>"><i class="fa fa-arrow-left"></i> Return to the last page you viewed</a>
+    </p>
+    <% end %>
+
+    <div class="<%= main_content_classes %>">
+
+    </div> 
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,19 +36,17 @@
         <%= render :partial => 'shared/header_navbar' %>
     <% end %>
 
-  <%= render partial: 'shared/ajax_modal' %>
+    <%= area :main do %>
+      <p>Main content goes here.</p>
+    <% end %>
 
-  <%= area :main do %>
-    <p>Main content goes here.</p>
-  <% end %>
+    <%= render :partial => 'shared/footer' %>
 
-  <%= render :partial => 'shared/footer' %>
-
-  <% if ENV['DEBUG_CSS'] %>
-  <div class="debug-breakpoints visible-xs-block">XS</div>
-  <div class="debug-breakpoints visible-sm-block">SM</div>
-  <div class="debug-breakpoints visible-md-block">MD</div>
-  <div class="debug-breakpoints visible-lg-block">LG</div>
-  <% end %>
+    <% if ENV['DEBUG_CSS'] %>
+    <div class="debug-breakpoints visible-xs-block">XS</div>
+    <div class="debug-breakpoints visible-sm-block">SM</div>
+    <div class="debug-breakpoints visible-md-block">MD</div>
+    <div class="debug-breakpoints visible-lg-block">LG</div>
+    <% end %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,17 @@ en:
       fishrappr_panel_title: Search Options
       fishrappr_graph_title: Results Frequency Graph
       fishrappr_graph_instructions: Hover the cursor over a bar to see its page count and select (click or tap) a bar to zoom in on its data. Bar sizes are relative to the bar with the highest number of results.
+    contacts:
+      types:
+        search: "Searching"
+        content: "Problem with content or metadata"
+        technical: "Technical support"
+        permissions: "Permissions request or question"
+        image: "Problem with image"
+        comment: "General comment or concern"
+        other: "Other"
+      prompts:
+        image: "Does something seem wrong with the image? Upside down or Rotated?"
     issue:
         next: '<span class="hidden-xs hidden-sm">Next <span class="hidden-sm">Page </span></span><span class="fa fa-arrow-right" aria-hidden="true"></span>'
         previous: '<span class="fa fa-arrow-left" aria-hidden="true"></span><span class="hidden-xs hidden-sm"> Previous<span class="hidden-sm"> Page</span></span>'


### PR DESCRIPTION
- tweak contact form styles to match zepplin mockups
- support prompts for different contact types
- allow contact form type to be initialized from URL parameters
- wire the "report problems" on the image viewer
- referer URLs are tracked for all contact submissions