### PR TITLE
ensure that titles can be gotten as plain text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,10 +67,12 @@ module ApplicationHelper
     document.fetch('issue_sequence')
   end
 
-  def issue_title(document, complete=false)
+  def issue_title(document, complete=false, html=true)
     title = document['date_issued_display'].first
     if complete
-      title += "<span class='hidden-xs'> " + issue_subtitle(document) + '</span>'
+      title += "<span class='hidden-xs'>" if html
+      title +=  " " + issue_subtitle(document)
+      title += '</span>' if html
     end
     title.html_safe
   end

--- a/app/views/catalog/_document_share_metadata.html.erb
+++ b/app/views/catalog/_document_share_metadata.html.erb
@@ -1,6 +1,6 @@
 <%= tag(:meta, property: 'og:site_name', content: t('blacklight.application_name')) %>
-<%= tag(:meta, property: 'og:title', content: "#{issue_title(@document, true)} - Image #{current_image_sequence(@document)}") %>
-<%= tag(:meta, property: 'og:description', content: "Image #{current_image_sequence(@document)} of #{@issue_data[:pages].size} from the #{issue_title(@document, true)} publication of the Michigan Daily.") %>
+<%= tag(:meta, property: 'og:title', content: "#{issue_title(@document, true, false)} - Image #{current_image_sequence(@document)}") %>
+<%= tag(:meta, property: 'og:description', content: "Image #{current_image_sequence(@document)} of #{@issue_data[:pages].size} from the #{issue_title(@document, true, false)} publication of the Michigan Daily.") %>
 <%= tag(:meta, property: 'og:image', content: document_image_src(@document, size: '400,')) %>
 <%= tag(:meta, property: 'og:url', content: solr_document_url(@document)) %>
 <%= tag(:meta, name: 'twitter:card', content: 'summary_large_image') %>


### PR DESCRIPTION
On the page titles have a bit of structure so they become shorter in narrower contexts. That gets in the way of facebook/twitter harvesting.