### PR TITLE
use /tile/ path in image api for guanranteed-to-be-smaller images

### DIFF
--- a/app/assets/javascripts/page_image_viewer.js
+++ b/app/assets/javascripts/page_image_viewer.js
@@ -135,6 +135,9 @@
         url: manifest_url,
         method: 'GET',
         dataType: 'json',
+        headers: {
+          'X-DLXS-Limit': 'tile'
+        },
         xhrFields: {
           withCredentials: true
         },
@@ -143,6 +146,7 @@
           $map.data('loaded', true);
           page = data.sequences[0].canvases[0];
           var info_url = page.images[0].resource.service['@id'] + '/info.json';
+          // info_url = info_url.replace('/api/image/', '/api/tile/');
 
           imageHeight = data.sequences[0].canvases[0].height;
           imageWidth = data.sequences[0].canvases[0].width;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,7 +121,7 @@ module ApplicationHelper
 
   def document_thumbnail_src(document, **kw)
     size = kw.fetch(:size, ',250')
-    document_image_src(document, size: size)
+    document_image_src(document, size: size, thumbnail: true)
   end
 
   def document_thumbnail_style(document, **kw)

--- a/app/services/repository_service.rb
+++ b/app/services/repository_service.rb
@@ -35,7 +35,9 @@ class RepositoryService
     path_info = path_info.join('/')
     path_info += "." + format if ( format )
 
-    "#{dlxs_repository_url}/image/#{path_info}"
+    action_path = kw[:thumbnail] ? 'cap' : 'image'
+
+    "#{dlxs_repository_url}/#{action_path}/#{path_info}"
   end
 
   def dlxs_filename(document)


### PR DESCRIPTION
Tweaking requests to use Image API path that's tuned for only serving small images.