### PR TITLE
Set application_name based on publication

### DIFF
--- a/app/controllers/concerns/fishrappr/context.rb
+++ b/app/controllers/concerns/fishrappr/context.rb
@@ -11,7 +11,7 @@ module Fishrappr::Context
     end
     @publication = Publication.where(slug: session[:publication]).first
 
-    @page_title = @publication_name = @publication.title
+    @publication_name = @publication.title
 
   end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -14,4 +14,8 @@ module BlacklightHelper
     end
   end
 
+  def application_name
+    t("application_name.#{@publication.slug}")
+  end
+
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  application_name:
+    midaily: Michigan Daily Digital Archives
+    djnews: The Detroit Jewish News Digital Archives
   facets:
     front:
       facet-title: Only Front Pages


### PR DESCRIPTION
Override blacklight template to key `application_name` based on the publication slug.

Aside: we could have used `publication.title` but `midaily` has a title of _The Michigan Daily_, not _Michigan Daily Digital Archives_.

That publication title is re-used in the PDFs to refer to the source publication, not the digital archives, so it's probably best to keep them separate.