### PR TITLE
fix problems with contact success page

### DIFF
--- a/app/assets/stylesheets/modules/custom.scss
+++ b/app/assets/stylesheets/modules/custom.scss
@@ -1454,13 +1454,17 @@ body.blacklight-contacts-create {
 }
 
 .help-sbar {
-  margin-top: -120px;
+  margin-top: -100px;
+}
+
+.contacts-success .help-sbar {
+  margin-top: auto;
 }
 
 .help-sbar h2 {
   font-size: 24px;
   color: #6e6e6e;
-  margin-top: 20px;
+  // margin-top: 20px;
   padding-left: 5px;
 }
 

--- a/app/views/contacts/success.html.erb
+++ b/app/views/contacts/success.html.erb
@@ -1,22 +1,23 @@
 <% @page_title = t('views.static.contact.title') %>
 
-<div class="container-fluid">
-  <%= render partial: 'static/unified_sidebar' %>
+<div class="container-fluid contacts-success">
 
-  <div class="<%= main_content_classes %> help-middle-col">
-    <h2 classs="title"><%= t('views.static.contact.title') %></h2>
+    <div class="row ">
 
-    <div class="alert alert-block alert-success"><p>Thank you for your message!</p></div>
+      <%= fishrappr_render 'help_sidebar' %>    
 
-    <p class="para">We appreciate your help in making our services better for everyone.</p>
+      <div class="<%= main_content_classes %> help-middle-col">
 
-    <% unless @contact.referer.blank? %>
-    <p>
-      <a href="<%= @contact.referer %>"><i class="fa fa-arrow-left"></i> Return to the last page you viewed</a>
-    </p>
-    <% end %>
+        <h2 classs="title"><%= t('views.static.contact.title') %></h2>
+        <div class="alert alert-block alert-success"><p>Thank you for your message!</p></div>
 
-    <div class="<%= main_content_classes %>">
+        <p class="para">We appreciate your help in making our services better for everyone.</p>
 
+        <% unless @contact.referer.blank? %>
+          <p>
+            <a href="<%= @contact.referer %>"><i class="fa fa-arrow-left"></i> Return to the last page you viewed</a>
+          </p>
+        <% end %>
+      </div>
     </div> 
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,9 @@ en:
         zoom_in: '<span class="hidden-xs hidden-sm"> Zoom In </span>'
         zoom_out: '<span class="hidden-xs hidden-sm">Zoom Out </span>'
         search_highlights: '<span class="hidden-xs">Search <span class="hidden-sm">Keyword </span></span>Highlights'
+    static:
+      contact:
+        title: Contact Us    
     midaily-static:
       about-daily:
         title: About The Michigan Daily


### PR DESCRIPTION
- fixes some obvious problem with contacts success page
- restructured the success page to match the other help pages
- small adjustment to the .help-sbar css seemed to improve side bar positioning a bit
- adds .contacts-success .help-sbar { margin-top: auto; } to fix position of sbar on that page